### PR TITLE
make `Dimensions` be `SimpleRatio{Int8}`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,5 @@
 import Ratios: SimpleRatio
-import SaferIntegers: SafeInt
+import SaferIntegers: SafeInt8
 
 const INT_TYPE = SafeInt8
 const R = SimpleRatio{INT_TYPE}

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,6 @@
 import Ratios: SimpleRatio
 
-const R = SimpleRatio{Int}
+const R = SimpleRatio{Int8}
 const DIMENSION_NAMES = (:length, :mass, :time, :current, :temperature, :luminosity, :amount)
 const DIMENSION_SYNONYMS = (:𝐋, :𝐌, :𝐓, :𝐈, :𝚯, :𝐉, :𝐍)
 const SYNONYM_MAPPING = NamedTuple(DIMENSION_NAMES .=> DIMENSION_SYNONYMS)


### PR DESCRIPTION
This makes them a lot lighter weight (and faster for vector operations).