### PR TITLE
Cache `divgcd(::Int8, ::Int8)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,7 @@ authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
-Ratios = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-SaferIntegers = "88634af6-177f-5301-88b8-7819386cfa38"
 
 [weakdeps]
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
@@ -15,9 +13,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 DynamicQuantitiesUnitfulExt = "Unitful"
 
 [compat]
-Ratios = "0.4"
 Requires = "1"
-SaferIntegers = "3"
 Unitful = "1"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+SaferIntegers = "88634af6-177f-5301-88b8-7819386cfa38"
 
 [weakdeps]
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
@@ -14,6 +15,7 @@ DynamicQuantitiesUnitfulExt = "Unitful"
 
 [compat]
 Requires = "1"
+SaferIntegers = "3"
 Unitful = "1"
 julia = "1.6"
 

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -36,7 +36,7 @@ SUITE["with_quantity"] = let s = BenchmarkGroup()
     s["/y"] = @benchmarkable $f5(x, y) setup = (x = default(); y = default()) evals = 1000
     f6(x, y) = x^y
     s["^y"] = @benchmarkable $f6(x, y) setup = (x = default(); y = rand(-2:2)) evals = 1000
-    f9(x, y) = x + y
-    s["+y"] = @benchmarkable $f9(x, y) setup = (x = default(); y = default()) evals = 1000
+    f9(x, y) = x * y
+    s["*y"] = @benchmarkable $f9(x, y) setup = (x = default(); y = default()) evals = 1000
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -35,6 +35,6 @@ SUITE["with_quantity"] = let s = BenchmarkGroup()
     f5(x, y) = x / y
     s["/y"] = @benchmarkable $f5(x, y) setup = (x = default(); y = default()) evals = 1000
     f6(x, y) = x^y
-    s["^y"] = @benchmarkable $f6(x, y) setup = (x = default(); y = default() / dimension(default())) evals = 1000
+    s["^y"] = @benchmarkable $f6(x, y) setup = (x = default(); y = rand(-2:2)) evals = 1000
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -36,5 +36,7 @@ SUITE["with_quantity"] = let s = BenchmarkGroup()
     s["/y"] = @benchmarkable $f5(x, y) setup = (x = default(); y = default()) evals = 1000
     f6(x, y) = x^y
     s["^y"] = @benchmarkable $f6(x, y) setup = (x = default(); y = rand(-2:2)) evals = 1000
+    f9(x, y) = x + y
+    s["+y"] = @benchmarkable $f9(x, y) setup = (x = default(); y = default()) evals = 1000
     s
 end

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -3,7 +3,6 @@ module DynamicQuantities
 export Quantity, Dimensions, ustrip, dimension, valid
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
 
-include("cached_rational.jl")
 include("types.jl")
 include("utils.jl")
 include("math.jl")

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -6,6 +6,7 @@ export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
 include("types.jl")
 include("utils.jl")
 include("math.jl")
+include("cached_rational.jl")
 
 import Requires: @init, @require
 

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -3,10 +3,10 @@ module DynamicQuantities
 export Quantity, Dimensions, ustrip, dimension, valid
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
 
+include("cached_rational.jl")
 include("types.jl")
 include("utils.jl")
 include("math.jl")
-include("cached_rational.jl")
 
 import Requires: @init, @require
 

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -3,8 +3,6 @@ module DynamicQuantities
 export Quantity, Dimensions, ustrip, dimension, valid
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
 
-import Ratios: SimpleRatio
-
 include("types.jl")
 include("utils.jl")
 include("math.jl")

--- a/src/cached_rational.jl
+++ b/src/cached_rational.jl
@@ -1,41 +1,45 @@
+import SaferIntegers: SafeInt8
+
+const INT_TYPE = SafeInt8
+
 const gcd_table =
     Tuple(
         Tuple(
             if j == 0
-                (Int8(0), Int8(0))
+                (INT_TYPE(0), INT_TYPE(0))
             else
-                let (out1, out2) = Base.divgcd(Int8(i), Int8(j))
-                    (Int8(out1), Int8(out2))
+                let (out1, out2) = Base.divgcd(i, j)
+                    (INT_TYPE(out1), INT_TYPE(out2))
                 end
             end
-            for i = (typemin(Int8)+1):typemax(Int8)
+            for i = (Int(typemin(INT_TYPE))+1):Int(typemax(INT_TYPE))
         )
-        for j = (typemin(Int8)+1):typemax(Int8)
+        for j = (Int(typemin(INT_TYPE))+1):Int(typemax(INT_TYPE))
     );
 
-# Pirate divgcd to speed it up for Int8
-function cached_divgcd(x::Int8, y::Int8)
-    @inbounds gcd_table[y+128][x+128]
+# Pirate divgcd to speed it up for INT_TYPE
+function cached_divgcd(x::INT_TYPE, y::INT_TYPE)
+    @inbounds gcd_table[Int(y)+128][Int(x)+128]
 end
 
 """Cached rational number"""
 struct CRational{T} <: Real
     num::T
     den::T
-    global unsafe_rational(num::Integer, den::Integer) = new{Int8}(Int8(num), Int8(den))
+    global unsafe_rational(num::Integer, den::Integer) = new{INT_TYPE}(INT_TYPE(num), INT_TYPE(den))
 end
 
-CRational(num::Int8, den::Int8) =
+CRational(num::INT_TYPE, den::INT_TYPE) =
     let (num, den) = cached_divgcd(num, den)
         return unsafe_rational(num, den)
     end
-CRational(n::Int8) = unsafe_rational(n, one(n))
-CRational(n::Integer) = CRational(Int8(n))
-CRational(r::Rational{Int8}) = unsafe_rational(r.num, r.den)
-CRational(r::Rational) = CRational(Int8(r.num), Int8(r.den))
+CRational(n::INT_TYPE) = unsafe_rational(n, one(n))
+CRational(n::Integer) = CRational(INT_TYPE(n))
+CRational(r::Rational{INT_TYPE}) = unsafe_rational(r.num, r.den)
+CRational(r::Rational) = CRational(INT_TYPE(r.num), INT_TYPE(r.den))
 
-CRational{Int8}(n::Integer) = CRational(n)
-CRational{Int8}(r::Rational) = CRational(r)
+CRational{INT_TYPE}(n::Integer) = CRational(n)
+CRational{INT_TYPE}(r::Rational) = CRational(r)
 
 Base.:*(x::CRational, y::CRational) = CRational(x.num * y.num, x.den * y.den)
 Base.:+(x::CRational, y::CRational) =
@@ -46,7 +50,7 @@ Base.:-(x::CRational) = unsafe_rational(-x.num, x.den)
 Base.:-(x::CRational, y::CRational) = x + (-y)
 Base.:(==)(x::CRational, y::CRational) = (x.den == y.den) & (x.num == y.num)
 Base.iszero(x::CRational) = iszero(x.num)
-Base.isinteger(x::CRational) = x.den == one(Int8)
+Base.isinteger(x::CRational) = x.den == one(INT_TYPE)
 Base.convert(::Type{RI}, x::CRational) where {RI<:Rational} = RI(x.num, x.den)
 Base.string(x::CRational) = string(convert(Rational, x))
 Base.promote(x::CRational, y) = promote(convert(Rational, x), y)

--- a/src/cached_rational.jl
+++ b/src/cached_rational.jl
@@ -32,7 +32,7 @@ CRational(num::INT_TYPE, den::INT_TYPE) =
 CRational(n::INT_TYPE) = unsafe_rational(n, one(n))
 CRational(n::Integer) = CRational(INT_TYPE(n))
 CRational(r::Rational{INT_TYPE}) = unsafe_rational(r.num, r.den)
-CRational(r::Rational) = CRational(INT_TYPE(r.num), INT_TYPE(r.den))
+CRational(r::Rational) = unsafe_rational(INT_TYPE(r.num), INT_TYPE(r.den))
 
 CRational{INT_TYPE}(n::Integer) = CRational(n)
 CRational{INT_TYPE}(r::Rational) = CRational(r)

--- a/src/cached_rational.jl
+++ b/src/cached_rational.jl
@@ -1,0 +1,13 @@
+import Base: divgcd
+
+function _divgcd(x::Int8, y::Int8)
+    iszero(y) && return (zero(Int8), zero(Int8))
+    g = gcd(x, y)
+    div(x, g), div(y, g)
+end
+
+const gcd_table = Tuple(Tuple(_divgcd(Int8(i), Int8(j)) for i = (typemin(Int8)+1):typemax(Int8)) for j = (typemin(Int8)+1):typemax(Int8));
+
+function divgcd(x::Int8, y::Int8)
+    gcd_table[x+2-typemin(Int8)][y+2-typemin(Int8)]
+end

--- a/src/cached_rational.jl
+++ b/src/cached_rational.jl
@@ -1,12 +1,12 @@
-import Base: divgcd
-
 const gcd_table =
     Tuple(
         Tuple(
             if j == 0
-                Rational{Int8}.((0, 0))
+                (Int8(0), Int8(0))
             else
-                Rational{Int8}.(divgcd(Int16(i), Int16(j)))
+                let (out1, out2) = Base.divgcd(Int8(i), Int8(j))
+                    (Int8(out1), Int8(out2))
+                end
             end
             for i = (typemin(Int8)+1):typemax(Int8)
         )
@@ -14,6 +14,40 @@ const gcd_table =
     );
 
 # Pirate divgcd to speed it up for Int8
-function divgcd(x::Int8, y::Int8)
+function cached_divgcd(x::Int8, y::Int8)
     @inbounds gcd_table[y+128][x+128]
 end
+
+"""Cached rational number"""
+struct CRational{T} <: Real
+    num::T
+    den::T
+    global unsafe_rational(num::Integer, den::Integer) = new{Int8}(Int8(num), Int8(den))
+end
+
+CRational(num::Int8, den::Int8) =
+    let (num, den) = cached_divgcd(num, den)
+        return unsafe_rational(num, den)
+    end
+CRational(n::Int8) = unsafe_rational(n, one(n))
+CRational(n::Integer) = CRational(Int8(n))
+CRational(r::Rational{Int8}) = unsafe_rational(r.num, r.den)
+CRational(r::Rational) = CRational(Int8(r.num), Int8(r.den))
+
+CRational{Int8}(n::Integer) = CRational(n)
+CRational{Int8}(r::Rational) = CRational(r)
+
+Base.:*(x::CRational, y::CRational) = CRational(x.num * y.num, x.den * y.den)
+Base.:+(x::CRational, y::CRational) =
+    let (xd, yd) = cached_divgcd(x.den, y.den)
+        CRational(x.num * yd + y.num * xd, x.den * yd)
+    end
+Base.:-(x::CRational) = unsafe_rational(-x.num, x.den)
+Base.:-(x::CRational, y::CRational) = x + (-y)
+Base.:(==)(x::CRational, y::CRational) = (x.den == y.den) & (x.num == y.num)
+Base.iszero(x::CRational) = iszero(x.num)
+Base.isinteger(x::CRational) = x.den == one(Int8)
+Base.convert(::Type{RI}, x::CRational) where {RI<:Rational} = RI(x.num, x.den)
+Base.string(x::CRational) = string(convert(Rational, x))
+Base.promote(x::CRational, y) = promote(convert(Rational, x), y)
+Base.promote(x, y::CRational) = promote(x, convert(Rational, y))

--- a/src/cached_rational.jl
+++ b/src/cached_rational.jl
@@ -4,7 +4,7 @@ const gcd_table =
     Tuple(
         Tuple(
             if j == 0
-                (Rational{Int8}(0), Rational{Int8}(0))
+                Rational{Int8}.((0, 0))
             else
                 Rational{Int8}.(divgcd(Int16(i), Int16(j)))
             end

--- a/src/cached_rational.jl
+++ b/src/cached_rational.jl
@@ -1,7 +1,3 @@
-import SaferIntegers: SafeInt8
-
-const INT_TYPE = SafeInt8
-
 const gcd_table =
     Tuple(
         Tuple(

--- a/src/cached_rational.jl
+++ b/src/cached_rational.jl
@@ -1,13 +1,19 @@
 import Base: divgcd
 
-function _divgcd(x::Int8, y::Int8)
-    iszero(y) && return (zero(Int8), zero(Int8))
-    g = gcd(x, y)
-    div(x, g), div(y, g)
-end
+const gcd_table =
+    Tuple(
+        Tuple(
+            if j == 0
+                (Rational{Int8}(0), Rational{Int8}(0))
+            else
+                Rational{Int8}.(divgcd(Int16(i), Int16(j)))
+            end
+            for i = (typemin(Int8)+1):typemax(Int8)
+        )
+        for j = (typemin(Int8)+1):typemax(Int8)
+    );
 
-const gcd_table = Tuple(Tuple(_divgcd(Int8(i), Int8(j)) for i = (typemin(Int8)+1):typemax(Int8)) for j = (typemin(Int8)+1):typemax(Int8));
-
+# Pirate divgcd to speed it up for Int8
 function divgcd(x::Int8, y::Int8)
-    gcd_table[x+2-typemin(Int8)][y+2-typemin(Int8)]
+    @inbounds gcd_table[y+128][x+128]
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,5 +1,5 @@
 const INT_TYPE = Int8
-const R = Rational{INT_TYPE}
+const R = CRational{INT_TYPE}
 const ZERO = R(0)
 const DIMENSION_NAMES = (:length, :mass, :time, :current, :temperature, :luminosity, :amount)
 const DIMENSION_SYNONYMS = (:𝐋, :𝐌, :𝐓, :𝐈, :𝚯, :𝐉, :𝐍)

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,13 +1,13 @@
 import SaferIntegers: SafeInt8
 
 const INT_TYPE = SafeInt8
+include("cached_rational.jl")
 const R = CRational{INT_TYPE}
 const ZERO = R(0)
 const DIMENSION_NAMES = (:length, :mass, :time, :current, :temperature, :luminosity, :amount)
 const DIMENSION_SYNONYMS = (:𝐋, :𝐌, :𝐓, :𝐈, :𝚯, :𝐉, :𝐍)
 const SYNONYM_MAPPING = NamedTuple(DIMENSION_NAMES .=> DIMENSION_SYNONYMS)
 
-include("cached_rational.jl")
 
 """
     Dimensions

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,9 +1,13 @@
-const INT_TYPE = Int8
+import SaferIntegers: SafeInt8
+
+const INT_TYPE = SafeInt8
 const R = CRational{INT_TYPE}
 const ZERO = R(0)
 const DIMENSION_NAMES = (:length, :mass, :time, :current, :temperature, :luminosity, :amount)
 const DIMENSION_SYNONYMS = (:𝐋, :𝐌, :𝐓, :𝐈, :𝚯, :𝐉, :𝐍)
 const SYNONYM_MAPPING = NamedTuple(DIMENSION_NAMES .=> DIMENSION_SYNONYMS)
+
+include("cached_rational.jl")
 
 """
     Dimensions

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,8 +1,5 @@
-import Ratios: SimpleRatio
-import SaferIntegers: SafeInt
-
-const INT_TYPE = SafeInt
-const R = SimpleRatio{INT_TYPE}
+const INT_TYPE = Int8
+const R = Rational{INT_TYPE}
 const ZERO = R(0)
 const DIMENSION_NAMES = (:length, :mass, :time, :current, :temperature, :luminosity, :amount)
 const DIMENSION_SYNONYMS = (:𝐋, :𝐌, :𝐓, :𝐈, :𝚯, :𝐉, :𝐍)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -66,7 +66,6 @@ Base.show(io::IO, d::Dimensions) =
 Base.show(io::IO, q::Quantity) = q.valid ? print(io, q.value, " ", q.dimensions) : print(io, "INVALID")
 
 string_rational(x::Rational) = isinteger(x) ? string(x.num) : string(x)
-string_rational(x::SimpleRatio) = string_rational(x.num // x.den)
 pretty_print_exponent(io::IO, x::R) =
     let
         print(io, " ", to_superscript(string_rational(x)))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -78,7 +78,6 @@ to_superscript(s::AbstractString) = join(
     end
 )
 
-tryrationalize(::Type{RI}, x::RI) where {RI} = x
 tryrationalize(::Type{RI}, x::Rational) where {RI} = RI(x)
 tryrationalize(::Type{RI}, x::Integer) where {RI} = RI(x)
 tryrationalize(::Type{RI}, x) where {RI} = simple_ratio_rationalize(RI, x)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -65,7 +65,7 @@ Base.show(io::IO, d::Dimensions) =
     end
 Base.show(io::IO, q::Quantity) = q.valid ? print(io, q.value, " ", q.dimensions) : print(io, "INVALID")
 
-string_rational(x::Rational) = isinteger(x) ? string(x.num) : string(x)
+string_rational(x::CRational) = isinteger(x) ? string(x.num) : string(x)
 pretty_print_exponent(io::IO, x::R) =
     let
         print(io, " ", to_superscript(string_rational(x)))
@@ -78,6 +78,7 @@ to_superscript(s::AbstractString) = join(
     end
 )
 
+tryrationalize(::Type{RI}, x::RI) where {RI} = x
 tryrationalize(::Type{RI}, x::Rational) where {RI} = RI(x)
 tryrationalize(::Type{RI}, x::Integer) where {RI} = RI(x)
 tryrationalize(::Type{RI}, x) where {RI} = simple_ratio_rationalize(RI, x)

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -151,17 +151,3 @@ end
     q = Quantity(0.5, inv(d))
     @test q == Quantity(0.5, length=0.2, luminosity=-2)
 end
-
-@testset "Trigger overflow" begin
-    f(x, N) =
-        let
-            for _ = 1:N
-                x = x + R(2 // 3)
-                x = x - R(2 // 3)
-            end
-            x
-        end
-
-    @test f(R(5 // 7), 15) == R(5 // 7)
-    @test_throws OverflowError f(R(5 // 7), 20)
-end


### PR DESCRIPTION
This creates `cached_divgcd` with a specialized method for `Int8` which caches all results at compilation time. Can get a 4x speedup on vectorized computations with normal Rational{Int8}.

This defines a `CRational` struct that uses this `cached_divgcd` for relevant rational calculations

@oscardssmith