### PR TITLE
Fix upreferred issue by loading at runtime

### DIFF
--- a/ext/DynamicQuantitiesUnitfulExt.jl
+++ b/ext/DynamicQuantitiesUnitfulExt.jl
@@ -11,18 +11,20 @@ else
 end
 
 # This lets the user override the preferred units:
-const UNITFUL_EQUIVALENCIES = let basic = (length=u"m", mass=u"kg", time=u"s", current=u"A", temperature=u"K", luminosity=u"cd", amount=u"mol")
-    NamedTuple((k => Unitful.upreferred(basic[k]) for k in keys(basic)))
+function unitful_equivalences()
+    si_units = (length=u"m", mass=u"kg", time=u"s", current=u"A", temperature=u"K", luminosity=u"cd", amount=u"mol")
+    return NamedTuple((k => Unitful.upreferred(si_units[k]) for k in keys(si_units)))
 end
 
 Base.convert(::Type{Unitful.Quantity}, x::DynamicQuantities.Quantity) =
     let
         cumulator = DynamicQuantities.ustrip(x)
         dims = DynamicQuantities.dimension(x)
+        equiv = unitful_equivalences()
         for dim in keys(dims)
             value = dims[dim]
             iszero(value) && continue
-            cumulator *= UNITFUL_EQUIVALENCIES[dim]^value
+            cumulator *= equiv[dim]^value
         end
         cumulator
     end


### PR DESCRIPTION
This fixes #12.

@j-fu what do you think? This seems to fix things for me:

```julia
julia> using Unitful

julia> using DynamicQuantities

julia> Unitful.preferunits(u"km")

julia> x_km = 1.5u"km"
1.5 km

julia> x = 1.5u"m"
1.5 m

julia> x_km_dyn = convert(DynamicQuantities.Quantity, x_km)
1500.0 𝐋 ¹

julia> x_dyn = convert(DynamicQuantities.Quantity, x)
1.5 𝐋 ¹
```
