### PR TITLE
Add more utility functions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
 version = "0.5.0"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
@@ -15,6 +16,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 DynamicQuantitiesUnitfulExt = "Unitful"
 
 [compat]
+Compat = "^3.42, 4"
 Requires = "1"
 Tricks = "0.1"
 Unitful = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
 version = "0.4.0"
 
 [deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 

--- a/src/math.jl
+++ b/src/math.jl
@@ -42,3 +42,5 @@ Base.cbrt(d::AbstractDimensions{R}) where {R} = d^inv(convert(R, 3))
 Base.cbrt(q::AbstractQuantity) = new_quantity(typeof(q), cbrt(ustrip(q)), cbrt(dimension(q)))
 
 Base.abs(q::AbstractQuantity) = new_quantity(typeof(q), abs(ustrip(q)), dimension(q))
+Base.abs2(q::AbstractQuantity) = new_quantity(typeof(q), abs2(ustrip(q)), dimension(q)^2)
+Base.angle(q::AbstractQuantity{T}) where {T<:Complex} = angle(ustrip(q))

--- a/src/math.jl
+++ b/src/math.jl
@@ -45,4 +45,3 @@ Base.cbrt(q::AbstractQuantity) = new_quantity(typeof(q), cbrt(ustrip(q)), cbrt(d
 
 Base.abs(q::AbstractQuantity) = new_quantity(typeof(q), abs(ustrip(q)), dimension(q))
 Base.abs2(q::AbstractQuantity) = new_quantity(typeof(q), abs2(ustrip(q)), dimension(q)^2)
-Base.angle(q::AbstractQuantity{T}) where {T<:Complex} = angle(ustrip(q))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -117,8 +117,16 @@ pretty_print_exponent(io::IO, x) = print(io, to_superscript(string_rational(x)))
 const SUPERSCRIPT_MAPPING = ('⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹')
 const INTCHARS = ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9')
 to_superscript(s::AbstractString) = join(
-    map(replace(replace(s, "-" => "⁻"), r"//" => "ᐟ")) do c
-        c ∈ INTCHARS ? SUPERSCRIPT_MAPPING[parse(Int, c)+1] : c
+    map(s) do c
+        if c ∈ INTCHARS
+            SUPERSCRIPT_MAPPING[parse(Int, c)+1]
+        elseif c == "-"
+            '⁻'
+        elseif c == "/"
+            'ᐟ'
+        else
+            c
+        end
     end
 )
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -88,6 +88,7 @@ Base.show(io::IO, d::AbstractDimensions) =
         print(io, s)
     end
 Base.show(io::IO, q::AbstractQuantity) = print(io, ustrip(q), " ", dimension(q))
+Base.show(io::IO, q::AbstractQuantity{<:Complex}) = print(io, "(", ustrip(q), ") ", dimension(q))
 
 function dimension_name(::AbstractDimensions, k::Symbol)
     default_dimensions = (length="m", mass="kg", time="s", current="A", temperature="K", luminosity="cd", amount="mol")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -94,12 +94,10 @@ Base.oneunit(::Type{<:AbstractDimensions}) = error("There is no such thing as a 
 
 Base.show(io::IO, d::AbstractDimensions) =
     let tmp_io = IOBuffer()
-        for k in keys(d)
-            if !iszero(d[k])
-                print(tmp_io, dimension_name(d, k))
-                isone(d[k]) || pretty_print_exponent(tmp_io, d[k])
-                print(tmp_io, " ")
-            end
+        for k in filter(k -> !iszero(d[k]), keys(d))
+            print(tmp_io, dimension_name(d, k))
+            isone(d[k]) || pretty_print_exponent(tmp_io, d[k])
+            print(tmp_io, " ")
         end
         s = String(take!(tmp_io))
         s = replace(s, r"^\s*" => "")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -68,7 +68,7 @@ end
 for f in (:one, :typemin, :typemax)
     @eval begin
         Base.$f(::Type{Q}) where {T,R,Q<:AbstractQuantity{T,R}} = new_quantity(Q, $f(T), R)
-        Base.$f(::Type{Q}) where {T,Q<:AbstractQuantity{T}} = $f(Q{T, DEFAULT_DIM_TYPE})
+        Base.$f(::Type{Q}) where {T,Q<:AbstractQuantity{T}} = $f(constructor_of(Q){T, DEFAULT_DIM_TYPE})
         Base.$f(::Type{Q}) where {Q<:AbstractQuantity} = $f(Q{DEFAULT_VALUE_TYPE, DEFAULT_DIM_TYPE})
     end
     if f == :one  # Return empty dimensions, as should be multiplicative identity.
@@ -117,13 +117,11 @@ pretty_print_exponent(io::IO, x) = print(io, to_superscript(string_rational(x)))
 const SUPERSCRIPT_MAPPING = ('⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹')
 const INTCHARS = ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9')
 to_superscript(s::AbstractString) = join(
-    map(s) do c
+    map(replace(s, "//" => "ᐟ")) do c
         if c ∈ INTCHARS
             SUPERSCRIPT_MAPPING[parse(Int, c)+1]
-        elseif c == "-"
+        elseif c == '-'
             '⁻'
-        elseif c == "/"
-            'ᐟ'
         else
             c
         end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -44,6 +44,8 @@ Base.iterate(::AbstractQuantity, ::Nothing) = nothing
 
 # Numeric checks
 Base.isapprox(l::AbstractQuantity, r::AbstractQuantity; kws...) = isapprox(ustrip(l), ustrip(r); kws...) && dimension(l) == dimension(r)
+Base.isapprox(l, r::AbstractQuantity; kws...) = iszero(dimension(r)) ? isapprox(l, ustrip(r); kws...) : throw(DimensionError(l, r))
+Base.isapprox(l::AbstractQuantity, r; kws...) = iszero(dimension(l)) ? isapprox(ustrip(l), r; kws...) : throw(DimensionError(l, r))
 Base.iszero(d::AbstractDimensions) = all_dimensions(iszero, d)
 Base.:(==)(l::AbstractDimensions, r::AbstractDimensions) = all_dimensions(==, l, r)
 Base.:(==)(l::AbstractQuantity, r::AbstractQuantity) = ustrip(l) == ustrip(r) && dimension(l) == dimension(r)
@@ -60,6 +62,7 @@ end
 
 # Simple operations which return a full quantity (same dimensions)
 norm(q::AbstractQuantity, p::Real=2) = new_quantity(typeof(q), norm(ustrip(q), p), dimension(q))
+norm(q::AbstractArray{<:AbstractQuantity}, p::Real=2) = new_quantity(eltype(q), norm(ustrip(q), p), dimension(q))
 for f in (:real, :imag, :conj, :adjoint, :unsigned, :nextfloat, :prevfloat)
     @eval Base.$f(q::AbstractQuantity) = new_quantity(typeof(q), $f(ustrip(q)), dimension(q))
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,6 @@
 import Tricks: static_fieldnames
 import LinearAlgebra: norm
+import Compat: allequal
 
 function map_dimensions(f::F, args::AbstractDimensions...) where {F<:Function}
     dimension_type = promote_type(typeof(args).parameters...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -38,6 +38,12 @@ Base.keys(d::AbstractDimensions) = static_fieldnames(typeof(d))
 Base.iszero(d::AbstractDimensions) = all_dimensions(iszero, d)
 Base.iszero(q::AbstractQuantity) = iszero(ustrip(q))
 Base.getindex(d::AbstractDimensions, k::Symbol) = getfield(d, k)
+
+# Compatibility with `.*`
+Base.length(::Union{AbstractQuantity,AbstractDimensions}) = 1
+Base.iterate(qd::Union{AbstractQuantity,AbstractDimensions}) = (qd, nothing)
+Base.iterate(::Union{AbstractQuantity,AbstractDimensions}, ::Nothing) = nothing
+
 Base.:(==)(l::AbstractDimensions, r::AbstractDimensions) = all_dimensions(==, l, r)
 Base.:(==)(l::AbstractQuantity, r::AbstractQuantity) = ustrip(l) == ustrip(r) && dimension(l) == dimension(r)
 Base.:(==)(l, r::AbstractQuantity) = ustrip(l) == ustrip(r) && iszero(dimension(r))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -114,8 +114,8 @@ end
 
 string_rational(x) = isinteger(x) ? string(round(Int, x)) : string(x)
 pretty_print_exponent(io::IO, x) = print(io, to_superscript(string_rational(x)))
-const SUPERSCRIPT_MAPPING = ['⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹']
-const INTCHARS = ['0' + i for i = 0:9]
+const SUPERSCRIPT_MAPPING = ('⁰', '¹', '²', '³', '⁴', '⁵', '⁶', '⁷', '⁸', '⁹')
+const INTCHARS = ('0', '1', '2', '3', '4', '5', '6', '7', '8', '9')
 to_superscript(s::AbstractString) = join(
     map(replace(replace(s, "-" => "⁻"), r"//" => "ᐟ")) do c
         c ∈ INTCHARS ? SUPERSCRIPT_MAPPING[parse(Int, c)+1] : c

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -148,6 +148,7 @@ Remove the units from a quantity.
 """
 ustrip(q::AbstractQuantity) = q.value
 ustrip(::AbstractDimensions) = error("Cannot remove units from an `AbstractDimensions` object.")
+ustrip(aq::AbstractArray{<:AbstractQuantity}) = ustrip.(aq)
 ustrip(q) = q
 
 """
@@ -157,6 +158,7 @@ Get the dimensions of a quantity, returning an `AbstractDimensions` object.
 """
 dimension(q::AbstractQuantity) = q.dimensions
 dimension(d::AbstractDimensions) = d
+dimension(aq::AbstractArray{<:AbstractQuantity}) = allequal(dimension.(aq)) ? dimension(first(aq)) : throw(DimensionError(aq[begin], aq[begin+1:end]))
 
 """
     ulength(q::AbstractQuantity)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -53,11 +53,10 @@ Base.isless(l::AbstractQuantity, r::AbstractQuantity) = dimension(l) == dimensio
 Base.isless(l::AbstractQuantity, r) = iszero(dimension(l)) ? isless(ustrip(l), r) : throw(DimensionError(l, r))
 Base.isless(l, r::AbstractQuantity) = iszero(dimension(r)) ? isless(l, ustrip(r)) : throw(DimensionError(l, r))
 
-# Simple operations which return a number by itself:
-for f in (:iszero, :isfinite, :isinf, :isnan, :isreal, :sign, :signbit, :eps)
+# Simple flags:
+for f in (:iszero, :isfinite, :isinf, :isnan, :isreal)
     @eval Base.$f(q::AbstractQuantity) = $f(ustrip(q))
 end
-Base.eps(::Type{Q}) where {T,Q<:AbstractQuantity{T}} = eps(T)
 
 # Simple operations which return a full quantity (same dimensions)
 norm(q::AbstractQuantity, p::Real=2) = new_quantity(typeof(q), norm(ustrip(q), p), dimension(q))

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -206,6 +206,8 @@ end
 
     @test norm(x, 2) ≈ norm(ustrip.(x), 2) * u"m/s"
     @test norm(Quantity(ustrip(x), length=1, time=-1), 2) ≈ norm(ustrip.(x), 2) * u"m/s"
+
+    @test ustrip(x') == ustrip(x)'
 end
 
 @testset "Alternate dimension construction" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -3,6 +3,7 @@ using DynamicQuantities: FixedRational
 using DynamicQuantities: DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
 using Ratios: SimpleRatio
 using SaferIntegers: SafeInt16
+using LinearAlgebra: norm
 using Test
 
 @testset "Basic utilities" begin
@@ -125,17 +126,42 @@ using Test
 
     x = Quantity(-1.2, length=2 // 5)
 
+    @test typemax(x) == Quantity(typemax(-1.2), length=2 // 5)
+    @test typemax(typeof(x)) == Quantity(typemax(typeof(-1.2)))
+
     @test abs(x) == Quantity(1.2, length=2 // 5)
     @test abs(x) == abs(Quantity(1.2, length=2 // 5))
+    @test abs2(x) == Quantity(abs2(-1.2), length=4 // 5)
+
+    @test iszero(x) == false
+    @test iszero(x * 0) == true
+    @test isfinite(x) == true
+    @test isfinite(x * Inf) == false
+    @test isfinite(x * NaN) == false
+    @test isinf(x * Inf) == true
+    @test isnan(x) == false
+    @test isnan(x * NaN) == true
+
+    @test nextfloat(x) == Quantity(nextfloat(-1.2), length=2 // 5)
+    @test prevfloat(x) == Quantity(prevfloat(-1.2), length=2 // 5)
+
+    y = Quantity(-1, mass=1)
+    @test unsigned(y) == Quantity(unsigned(-1), mass=1)
 end
 
 @testset "Complex numbers" begin
-    x = (0.5 + 0.5im) * u"km/s"
-    @test string(x) == "(500.0 + 500.0im) m s⁻¹"
+    x = (0.5 + 0.6im) * u"km/s"
+    @test string(x) == "(500.0 + 600.0im) m s⁻¹"
     @test typeof(x) == Quantity{Complex{Float64}, DEFAULT_DIM_TYPE}
     @test typeof(x^2) == Quantity{Complex{Float64}, DEFAULT_DIM_TYPE}
-    @test x^2/u"km/s"^2 == Quantity(0.5im)
-    @test x^2.5 ≈ (-5.088059320440205e6 + 1.2283661817565577e7im) * u"m^(5/2) * s^(-5/2)"
+    @test x^2/u"km/s"^2 ≈ (0.5 + 0.6im)^2
+    @test x^2.5 ≈ (-9.896195997465055e6 + 1.38810912834778e7im) * u"m^(5/2) * s^(-5/2)"
+    @test isreal(x) == false
+    @test isreal(abs2(x)) == true
+    @test real(x) == 0.5 * u"km/s"
+    @test imag(x) == 0.6 * u"km/s"
+    @test conj(x) == (0.5 - 0.6im) * u"km/s"
+    @test adjoint(ustrip(x^2)) ≈ adjoint(x^2) / u"m/s"^2
 end
 
 @testset "Fallbacks" begin
@@ -172,6 +198,14 @@ end
         @test typeof(ones(T, 32) / Quantity(T(1), D, length=1)) <: Quantity{Vector{T}}
         @test ones(T, 32) / Quantity(T(1), length=1) == Quantity(ones(T, 32), length=-1)
     end
+
+    x = randn(32) .* u"km/s"
+    @test ustrip(x) == ustrip.(x)
+    @test dimension(x) == dimension(u"km/s")
+    @test_throws DimensionError dimension([u"km/s", u"km"])
+
+    @test norm(x, 2) ≈ norm(ustrip.(x), 2) * u"m/s"
+    @test norm(Quantity(ustrip(x), length=1, time=-1), 2) ≈ norm(ustrip.(x), 2) * u"m/s"
 end
 
 @testset "Alternate dimension construction" begin


### PR DESCRIPTION
Just to bring more compatibility with Unitful.jl. Here's the list of added functions:

- abs2
- angle
- LinearAlgebra.norm
- isinf
- isnan
- isreal
- sign
- signbit
- real
- imag
- conj
- adjoint
- unsigned
- nextfloat
- prevfloat
- eps
- typemin
- typemax

This also fixes printing for complex numbers (now surrounds them with parentheses)