### PR TITLE
Create LazyFloat64 type for units

### DIFF
--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -6,13 +6,15 @@ export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
 export uparse, @u_str
 
 include("fixed_rational.jl")
+include("lazy_float.jl")
+
 include("types.jl")
 include("utils.jl")
 include("math.jl")
 include("units.jl")
 
 import Requires: @init, @require
-import .Units: uparse, @u_str
+import .Units: uparse, @u_str, DEFAULT_UNIT_TYPE
 
 if !isdefined(Base, :get_extension)
     @init @require Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d" include("../ext/DynamicQuantitiesUnitfulExt.jl")

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,12 +1,11 @@
 module Constants
 
-import ..DEFAULT_QUANTITY_TYPE
 import ..Quantity
 import ..Units as U
-import ..Units: _add_prefixes
+import ..Units: _add_prefixes, DEFAULT_UNIT_TYPE
 
 const _CONSTANT_SYMBOLS = Symbol[]
-const _CONSTANT_VALUES = DEFAULT_QUANTITY_TYPE[]
+const _CONSTANT_VALUES = DEFAULT_UNIT_TYPE[]
 
 macro register_constant(name, value)
     return esc(_register_constant(name, value))
@@ -20,7 +19,7 @@ end
 function _register_constant(name::Symbol, value)
     s = string(name)
     return quote
-        const $name = $value
+        const $name = convert(DEFAULT_UNIT_TYPE, $value)
         push!(_CONSTANT_SYMBOLS, Symbol($s))
         push!(_CONSTANT_VALUES, $name)
     end
@@ -87,7 +86,7 @@ end
 )
 
 # Measured
-@register_constant alpha DEFAULT_QUANTITY_TYPE(7.2973525693e-3)
+@register_constant alpha DEFAULT_UNIT_TYPE(7.2973525693e-3)
 @register_constant u 1.66053906660e-27 * U.kg
 @register_constant G 6.67430e-11 * U.m^3 / (U.kg * U.s^2)
 @register_constant mu_0 4π * alpha * hbar / (e^2 * c)

--- a/src/lazy_float.jl
+++ b/src/lazy_float.jl
@@ -12,7 +12,8 @@ Base.convert(::Type{LazyFloat64}, x::LazyFloat64) = x
 Base.convert(::Type{LazyFloat64}, x::FixedRational) = LazyFloat64(convert(Float64, x))
 Base.convert(::Type{LazyFloat64}, x::Number) = LazyFloat64(x)
 Base.convert(::Type{T}, x::LazyFloat64) where {T<:Number} = convert(T, float(x))
-Base.promote_rule(::Type{LazyFloat64}, ::Type{T}) where {T} = T
+Base.promote_rule(::Type{LazyFloat64}, ::Type{T}) where {T<:AbstractFloat} = T
+Base.promote_rule(::Type{LazyFloat64}, ::Type{T}) where {T} = promote_type(Float64, T)
 
 (::Type{T})(x::LazyFloat64) where {T<:Number} = T(float(x))
 

--- a/src/lazy_float.jl
+++ b/src/lazy_float.jl
@@ -1,0 +1,32 @@
+# This is used to store floats without forcing promotion on other
+# numeric types.
+struct LazyFloat64 <: AbstractFloat
+    value::Float64
+end
+
+LazyFloat64(x::LazyFloat64) = x
+LazyFloat64(x::Number) = LazyFloat64(convert(Float64, x))
+float(x::LazyFloat64) = x.value
+
+Base.convert(::Type{LazyFloat64}, x::LazyFloat64) = x
+Base.convert(::Type{LazyFloat64}, x::FixedRational) = LazyFloat64(convert(Float64, x))
+Base.convert(::Type{LazyFloat64}, x::Number) = LazyFloat64(x)
+Base.convert(::Type{T}, x::LazyFloat64) where {T<:Number} = convert(T, float(x))
+Base.promote_rule(::Type{LazyFloat64}, ::Type{T}) where {T} = T
+
+(::Type{T})(x::LazyFloat64) where {T<:Number} = T(float(x))
+
+Base.show(io::IO, x::LazyFloat64) = print(io, float(x))
+
+Base.:+(a::LazyFloat64, b::LazyFloat64) = LazyFloat64(float(a) + float(b))
+Base.:-(a::LazyFloat64) = LazyFloat64(-float(a))
+Base.:-(a::LazyFloat64, b::LazyFloat64) = LazyFloat64(float(a) - float(b))
+Base.:*(a::LazyFloat64, b::LazyFloat64) = LazyFloat64(float(a) * float(b))
+Base.inv(a::LazyFloat64) = LazyFloat64(inv(float(a)))
+Base.abs(a::LazyFloat64) = LazyFloat64(abs(float(a)))
+Base.:/(a::LazyFloat64, b::LazyFloat64) = a * inv(b)
+Base.:^(a::LazyFloat64, b::Int) = LazyFloat64(float(a) ^ b)
+Base.:^(a::LazyFloat64, b::LazyFloat64) = LazyFloat64(float(a) ^ float(b))
+Base.sqrt(a::LazyFloat64) = LazyFloat64(sqrt(float(a)))
+Base.cbrt(a::LazyFloat64) = LazyFloat64(cbrt(float(a)))
+Base.eps(::Type{LazyFloat64}) = eps(Float64)

--- a/src/units.jl
+++ b/src/units.jl
@@ -7,7 +7,7 @@ import ..Quantity
 import ..LazyFloat64
 
 const DEFAULT_UNIT_BASE_TYPE = LazyFloat64
-const DEFAULT_UNIT_TYPE = Quantity{DEFAULT_UNIT_TYPE,DEFAULT_DIM_TYPE}
+const DEFAULT_UNIT_TYPE = Quantity{DEFAULT_UNIT_BASE_TYPE,DEFAULT_DIM_TYPE}
 
 const _UNIT_SYMBOLS = Symbol[]
 const _UNIT_VALUES = DEFAULT_UNIT_TYPE[]

--- a/src/units.jl
+++ b/src/units.jl
@@ -57,9 +57,9 @@ const mol = Quantity(DEFAULT_UNIT_TYPE(1.0), amount=1)
 "Frequency in Hertz. Available variants: `kHz`, `MHz`, `GHz`."
 const Hz = inv(s)
 "Force in Newtons."
-const N = kg * m / (s * s)
+const N = kg * m / s^2
 "Pressure in Pascals. Available variant: `kPa`."
-const Pa = N / (m * m)
+const Pa = N / m^2
 "Energy in Joules. Available variant: `kJ`."
 const J = N * m
 "Power in Watts. Available variants: `kW`, `MW`, `GW`."
@@ -104,7 +104,7 @@ const yr = DEFAULT_UNIT_TYPE(365.25) * day
 
 ## Volume
 "Volume in liters. Available variants: `mL`, `dL`."
-const L = dm * dm * dm
+const L = dm^3
 
 @add_prefixes L (m, d)
 
@@ -127,12 +127,12 @@ Parse a string containing an expression of units and return the
 corresponding `Quantity` object with `Float64` value. For example,
 `uparse("m/s")` would be parsed to `Quantity(1.0, length=1, time=-1)`.
 """
-function uparse(s::AbstractString)::Quantity{LazyFloat64,DEFAULT_DIM_TYPE}
+function uparse(s::AbstractString)::Quantity{DEFAULT_UNIT_TYPE,DEFAULT_DIM_TYPE}
     return as_quantity(eval(Meta.parse(s)))
 end
 
 as_quantity(q::Quantity) = q
-as_quantity(x::Number) = Quantity(convert(LazyFloat64, x), DEFAULT_DIM_TYPE)
+as_quantity(x::Number) = Quantity(convert(DEFAULT_UNIT_TYPE, x), DEFAULT_DIM_TYPE)
 as_quantity(x) = error("Unexpected type evaluated: $(typeof(x))")
 
 """

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1,6 +1,6 @@
 using DynamicQuantities
 using DynamicQuantities: FixedRational
-using DynamicQuantities: DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
+using DynamicQuantities: DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE, DEFAULT_UNIT_TYPE
 using Ratios: SimpleRatio
 using SaferIntegers: SafeInt16
 using Test
@@ -335,13 +335,22 @@ end
     @test ustrip(z) ≈ 60 * 60 * 24 * 365.25
 
     # Test type stability of extreme range of units
-    @test typeof(u"1") == Quantity{Float64,DEFAULT_DIM_TYPE}
-    @test typeof(u"1f0") == Quantity{Float64,DEFAULT_DIM_TYPE}
-    @test typeof(u"s"^2) == Quantity{Float64,DEFAULT_DIM_TYPE}
-    @test typeof(u"Ω") == Quantity{Float64,DEFAULT_DIM_TYPE}
-    @test typeof(u"Gyr") == Quantity{Float64,DEFAULT_DIM_TYPE}
-    @test typeof(u"fm") == Quantity{Float64,DEFAULT_DIM_TYPE}
-    @test typeof(u"fm"^2) == Quantity{Float64,DEFAULT_DIM_TYPE}
+    @test typeof(u"1") == Quantity{DEFAULT_UNIT_TYPE,DEFAULT_DIM_TYPE}
+    @test typeof(u"1f0") == Quantity{DEFAULT_UNIT_TYPE,DEFAULT_DIM_TYPE}
+    @test typeof(u"s"^2) == Quantity{DEFAULT_UNIT_TYPE,DEFAULT_DIM_TYPE}
+    @test typeof(u"Ω") == Quantity{DEFAULT_UNIT_TYPE,DEFAULT_DIM_TYPE}
+    @test typeof(u"Gyr") == Quantity{DEFAULT_UNIT_TYPE,DEFAULT_DIM_TYPE}
+    @test typeof(u"fm") == Quantity{DEFAULT_UNIT_TYPE,DEFAULT_DIM_TYPE}
+    @test typeof(u"fm"^2) == Quantity{DEFAULT_UNIT_TYPE,DEFAULT_DIM_TYPE}
+
+    # Test type demotion
+    @test typeof(1u"m") == Quantity{Int64,DEFAULT_DIM_TYPE}
+    @test typeof(1f0u"m") == Quantity{Float32,DEFAULT_DIM_TYPE}
+    @test typeof(1.0u"m") == Quantity{Float64,DEFAULT_DIM_TYPE}
+
+    @test typeof(1u"m^2/s") == Quantity{Int64,DEFAULT_DIM_TYPE}
+    @test typeof(1f0u"m^2/s") == Quantity{Float32,DEFAULT_DIM_TYPE}
+    @test typeof(1.0u"m^2/s") == Quantity{Float64,DEFAULT_DIM_TYPE}
 
     @test_throws LoadError eval(:(u":x"))
 end


### PR DESCRIPTION
This PR creates the `LazyFloat64` type for storing units. It makes units try to _demote_ their numeric type, rather than promote everything to `Float64`:

```julia
julia> typeof(1u"m/s")
Quantity{Int64, Dimensions{DynamicQuantities.FixedRational{Int32, 25200}}}

julia> typeof(1.0u"m/s")
Quantity{Float64, Dimensions{DynamicQuantities.FixedRational{Int32, 25200}}}

julia> typeof(1f0u"m^2.5")
Quantity{Float32, Dimensions{DynamicQuantities.FixedRational{Int32, 25200}}}

julia> typeof(1u"fm")
ERROR: InexactError: Int64(1.0e-15)
```

@mcabbott could you review this?