### PR TITLE
Create `QuantityArray <: AbstractArray`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "DynamicQuantities"
 uuid = "06fc5a27-2a28-4c7c-a15d-362465fb6821"
 authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
-version = "0.6.3"
+version = "0.7.0"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [weakdeps]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["MilesCranmer <miles.cranmer@gmail.com> and contributors"]
 version = "0.6.0"
 
 [deps]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -16,6 +17,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 DynamicQuantitiesUnitfulExt = "Unitful"
 
 [compat]
+Compat = "^3.42, 4"
 Requires = "1"
 Tricks = "0.1"
 Unitful = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -38,8 +38,9 @@ SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SaferIntegers = "88634af6-177f-5301-88b8-7819386cfa38"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Test", "Aqua", "LinearAlgebra", "Ratios", "SaferIntegers", "SafeTestsets", "ScientificTypes", "ScientificTypesBase", "Unitful"]
+test = ["Test", "Aqua", "LinearAlgebra", "Ratios", "SaferIntegers", "SafeTestsets", "ScientificTypes", "ScientificTypesBase", "StaticArrays", "Unitful"]

--- a/Project.toml
+++ b/Project.toml
@@ -5,17 +5,18 @@ version = "0.6.3"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [weakdeps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
+DynamicQuantitiesLinearAlgebraExt = "LinearAlgebra"
 DynamicQuantitiesScientificTypesExt = ["ScientificTypes", "ScientificTypesBase"]
 DynamicQuantitiesUnitfulExt = "Unitful"
 
@@ -30,6 +31,7 @@ julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Ratios = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SaferIntegers = "88634af6-177f-5301-88b8-7819386cfa38"
@@ -39,4 +41,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Test", "Aqua", "Ratios", "SaferIntegers", "SafeTestsets", "ScientificTypes", "ScientificTypesBase", "Unitful"]
+test = ["Test", "Aqua", "LinearAlgebra", "Ratios", "SaferIntegers", "SafeTestsets", "ScientificTypes", "ScientificTypesBase", "Unitful"]

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -47,17 +47,17 @@ if @isdefined QuantityArray
     SUITE["QuantityArray"]["broadcasting"] = let s = BenchmarkGroup()
         N = 10000
         f9(x) = x^2
-        s["x^2_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000
-        s["x^2_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-        s["x^2_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+        s["x^2_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N))
+        s["x^2_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s"))
+        s["x^2_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s")
         f10(x) = x^4
-        s["x^4_normal_array"] = @benchmarkable $f10.(arr) setup = (arr = randn($N)) evals = 1000
-        s["x^4_quantity_array"] = @benchmarkable $f10.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-        s["x^4_array_of_quantities"] = @benchmarkable $f10.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+        s["x^4_normal_array"] = @benchmarkable $f10.(arr) setup = (arr = randn($N))
+        s["x^4_quantity_array"] = @benchmarkable $f10.(arr) setup = (arr = QuantityArray(randn($N), u"km/s"))
+        s["x^4_array_of_quantities"] = @benchmarkable $f10.(arr) setup = (arr = randn($N) .* u"km/s")
         f11(x) = x^4 * 0.9 - x * x / 0.3 * x * 0.9 * x
-        s["multi_normal_array"] = @benchmarkable $f11.(arr) setup = (arr = randn($N)) evals = 1000
-        s["multi_quantity_array"] = @benchmarkable $f11.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-        s["multi_array_of_quantities"] = @benchmarkable $f11.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+        s["multi_normal_array"] = @benchmarkable $f11.(arr) setup = (arr = randn($N))
+        s["multi_quantity_array"] = @benchmarkable $f11.(arr) setup = (arr = QuantityArray(randn($N), u"km/s"))
+        s["multi_array_of_quantities"] = @benchmarkable $f11.(arr) setup = (arr = randn($N) .* u"km/s")
         s
     end
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -50,8 +50,8 @@ SUITE["QuantityArray"]["broadcasting"] = let s = BenchmarkGroup()
     s["x^2_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
     s["x^2_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
     f10(x) = x^4
-    s["x^4_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
-    s["x^4_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-    s["x^4_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+    s["x^4_normal_array"] = @benchmarkable $f10.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
+    s["x^4_quantity_array"] = @benchmarkable $f10.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
+    s["x^4_array_of_quantities"] = @benchmarkable $f10.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -46,12 +46,16 @@ SUITE["QuantityArray"] = BenchmarkGroup()
 SUITE["QuantityArray"]["broadcasting"] = let s = BenchmarkGroup()
     N = 10000
     f9(x) = x^2
-    s["x^2_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
+    s["x^2_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000
     s["x^2_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
     s["x^2_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
     f10(x) = x^4
-    s["x^4_normal_array"] = @benchmarkable $f10.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
+    s["x^4_normal_array"] = @benchmarkable $f10.(arr) setup = (arr = randn($N)) evals = 1000
     s["x^4_quantity_array"] = @benchmarkable $f10.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
     s["x^4_array_of_quantities"] = @benchmarkable $f10.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+    f11(x) = x^4 * 0.9 - x * x / 0.3 * x * 0.9 * x
+    s["multi_normal_array"] = @benchmarkable $f11.(arr) setup = (arr = randn($N)) evals = 1000
+    s["multi_quantity_array"] = @benchmarkable $f11.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
+    s["multi_array_of_quantities"] = @benchmarkable $f11.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -41,7 +41,7 @@ SUITE["Quantity"]["with_quantity"] = let s = BenchmarkGroup()
     s
 end
 
-if PACKAGE_VERSION > v"0.7"
+if @isdefined QuantityArray
     SUITE["QuantityArray"] = BenchmarkGroup()
 
     SUITE["QuantityArray"]["broadcasting"] = let s = BenchmarkGroup()

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -41,21 +41,23 @@ SUITE["Quantity"]["with_quantity"] = let s = BenchmarkGroup()
     s
 end
 
-SUITE["QuantityArray"] = BenchmarkGroup()
+if PACKAGE_VERSION > v"0.7"
+    SUITE["QuantityArray"] = BenchmarkGroup()
 
-SUITE["QuantityArray"]["broadcasting"] = let s = BenchmarkGroup()
-    N = 10000
-    f9(x) = x^2
-    s["x^2_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000
-    s["x^2_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-    s["x^2_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
-    f10(x) = x^4
-    s["x^4_normal_array"] = @benchmarkable $f10.(arr) setup = (arr = randn($N)) evals = 1000
-    s["x^4_quantity_array"] = @benchmarkable $f10.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-    s["x^4_array_of_quantities"] = @benchmarkable $f10.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
-    f11(x) = x^4 * 0.9 - x * x / 0.3 * x * 0.9 * x
-    s["multi_normal_array"] = @benchmarkable $f11.(arr) setup = (arr = randn($N)) evals = 1000
-    s["multi_quantity_array"] = @benchmarkable $f11.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-    s["multi_array_of_quantities"] = @benchmarkable $f11.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
-    s
+    SUITE["QuantityArray"]["broadcasting"] = let s = BenchmarkGroup()
+        N = 10000
+        f9(x) = x^2
+        s["x^2_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000
+        s["x^2_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
+        s["x^2_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+        f10(x) = x^4
+        s["x^4_normal_array"] = @benchmarkable $f10.(arr) setup = (arr = randn($N)) evals = 1000
+        s["x^4_quantity_array"] = @benchmarkable $f10.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
+        s["x^4_array_of_quantities"] = @benchmarkable $f10.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+        f11(x) = x^4 * 0.9 - x * x / 0.3 * x * 0.9 * x
+        s["multi_normal_array"] = @benchmarkable $f11.(arr) setup = (arr = randn($N)) evals = 1000
+        s["multi_quantity_array"] = @benchmarkable $f11.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
+        s["multi_array_of_quantities"] = @benchmarkable $f11.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+        s
+    end
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -46,12 +46,12 @@ SUITE["QuantityArray"] = BenchmarkGroup()
 SUITE["QuantityArray"]["broadcasting"] = let s = BenchmarkGroup()
     N = 10000
     f9(x) = x^2
-    s["pow2_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
-    s["pow2_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-    s["pow2_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+    s["x^2_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
+    s["x^2_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
+    s["x^2_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
     f10(x) = x^4
-    s["pow4_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
-    s["pow4_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-    s["pow4_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+    s["x^4_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
+    s["x^4_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
+    s["x^4_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
     s
 end

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -3,7 +3,9 @@ using DynamicQuantities
 
 const SUITE = BenchmarkGroup()
 
-SUITE["creation"] = let s = BenchmarkGroup()
+SUITE["Quantity"] = BenchmarkGroup()
+
+SUITE["Quantity"]["creation"] = let s = BenchmarkGroup()
     s["Quantity(x)"] = @benchmarkable Quantity(x) setup = (x = randn()) evals = 1000
     s["Quantity(x, length=y)"] = @benchmarkable Quantity(x, length=y) setup = (x = randn(); y = rand(1:5)) evals = 1000
     s
@@ -11,7 +13,7 @@ end
 
 default() = Quantity(rand(), length=rand(1:5), mass=rand(1:5) // 2)
 
-SUITE["with_numbers"] = let s = BenchmarkGroup()
+SUITE["Quantity"]["with_numbers"] = let s = BenchmarkGroup()
     f1(x, i) = x^i
     s["^int"] = @benchmarkable $f1(x, i) setup = (x = default(); i = rand(1:5)) evals = 1000
     f2(x, y) = x * y
@@ -21,7 +23,7 @@ SUITE["with_numbers"] = let s = BenchmarkGroup()
     s
 end
 
-SUITE["with_self"] = let s = BenchmarkGroup()
+SUITE["Quantity"]["with_self"] = let s = BenchmarkGroup()
     f4(x) = inv(x)
     s["inv"] = @benchmarkable $f4(x) setup = (x = default()) evals = 1000
     f7(x) = ustrip(x)
@@ -31,7 +33,7 @@ SUITE["with_self"] = let s = BenchmarkGroup()
     s
 end
 
-SUITE["with_quantity"] = let s = BenchmarkGroup()
+SUITE["Quantity"]["with_quantity"] = let s = BenchmarkGroup()
     f5(x, y) = x / y
     s["/y"] = @benchmarkable $f5(x, y) setup = (x = default(); y = default()) evals = 1000
     f6(x, y) = x + y
@@ -39,15 +41,17 @@ SUITE["with_quantity"] = let s = BenchmarkGroup()
     s
 end
 
-SUITE["with_array"] = let s = BenchmarkGroup()
+SUITE["QuantityArray"] = BenchmarkGroup()
+
+SUITE["QuantityArray"]["broadcasting"] = let s = BenchmarkGroup()
     N = 10000
     f9(x) = x^2
-    s["arr.^2"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
-    s["qarr.^2"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-    s["arrq.^2"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+    s["pow2_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
+    s["pow2_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
+    s["pow2_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
     f10(x) = x^4
-    s["arr.^4"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
-    s["qarr.^4"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
-    s["arrq.^4"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
+    s["pow4_normal_array"] = @benchmarkable $f9.(arr) setup = (arr = randn($N)) evals = 1000 # baseline
+    s["pow4_quantity_array"] = @benchmarkable $f9.(arr) setup = (arr = QuantityArray(randn($N), u"km/s")) evals = 1000
+    s["pow4_array_of_quantities"] = @benchmarkable $f9.(arr) setup = (arr = randn($N) .* u"km/s") evals = 1000
     s
 end

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -17,8 +17,16 @@ AbstractQuantity
 Note also that the `Quantity` object can take a custom `AbstractDimensions`
 as input, so there is often no need to subtype `AbstractQuantity` separately.
 
+## Symbolic dimensions
+
 Another type which subtypes `AbstractDimensions` is `SymbolicDimensions`:
 
 ```@docs
 SymbolicDimensions
+```
+
+## Arrays
+
+```@docs
+QuantityArray
 ```

--- a/ext/DynamicQuantitiesLinearAlgebraExt.jl
+++ b/ext/DynamicQuantitiesLinearAlgebraExt.jl
@@ -1,0 +1,9 @@
+module DynamicQuantitiesLinearAlgebraExt
+
+import LinearAlgebra: norm
+import DynamicQuantities: AbstractQuantity, ustrip, dimension, new_quantity
+
+norm(q::AbstractQuantity, p::Real=2) = new_quantity(typeof(q), norm(ustrip(q), p), dimension(q))
+norm(q::AbstractArray{<:AbstractQuantity}, p::Real=2) = new_quantity(eltype(q), norm(ustrip(q), p), dimension(q))
+
+end

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -1,5 +1,15 @@
 module DynamicQuantities
 
+import TOML: parsefile
+
+const PACKAGE_VERSION = try
+    let project = parsefile(joinpath(pkgdir(@__MODULE__), "Project.toml"))
+        VersionNumber(project["version"])
+    end
+catch
+    VersionNumber(0, 0, 0)
+end
+
 export Units, Constants
 export AbstractQuantity, AbstractDimensions
 export Quantity, Dimensions, SymbolicDimensions, QuantityArray, DimensionError

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -69,21 +69,45 @@ end
 @inline ustrip(A::QuantityArray) = A.value
 @inline dimension(A::QuantityArray) = A.dimensions
 
-array_type(::Type{A}) where {T,A<:QuantityArray{T}} = Array{T,1}
+array_type(::Type{A}) where {A<:QuantityArray} = Array{T,N} where {T,N}
+array_type(::Type{A}) where {T,A<:QuantityArray{T}} = Array{T,N} where {N}
 array_type(::Type{A}) where {T,N,A<:QuantityArray{T,N}} = Array{T,N}
+array_type(::Type{A}) where {T,N,D,A<:QuantityArray{T,N,D}} = Array{T,N}
+array_type(::Type{A}) where {T,N,D,Q,A<:QuantityArray{T,N,D,Q}} = Array{T,N}
 array_type(::Type{A}) where {T,N,D,Q,V,A<:QuantityArray{T,N,D,Q,V}} = V
+
 array_type(A) = array_type(typeof(A))
 
+quantity_type(::Type{A}) where {A<:QuantityArray} = DEFAULT_QUANTITY_TYPE
+quantity_type(::Type{A}) where {T,A<:QuantityArray{T}} = Quantity{T,DEFAULT_DIM_TYPE}
+quantity_type(::Type{A}) where {T,N,A<:QuantityArray{T,N}} = Quantity{T,DEFAULT_DIM_TYPE}
+quantity_type(::Type{A}) where {T,N,D,A<:QuantityArray{T,N,D}} = Quantity{T,D}
 quantity_type(::Type{A}) where {T,N,D,Q,A<:QuantityArray{T,N,D,Q}} = Q
+quantity_type(::Type{A}) where {T,N,D,Q,V,A<:QuantityArray{T,N,D,Q,V}} = Q
+
 quantity_type(A) = quantity_type(typeof(A))
 
 dim_type(::Type{A}) where {A<:QuantityArray} = DEFAULT_DIM_TYPE
+dim_type(::Type{A}) where {T,A<:QuantityArray{T}} = DEFAULT_DIM_TYPE
+dim_type(::Type{A}) where {T,N,A<:QuantityArray{T,N}} = DEFAULT_DIM_TYPE
 dim_type(::Type{A}) where {T,N,D,A<:QuantityArray{T,N,D}} = D
+dim_type(::Type{A}) where {T,N,D,Q,A<:QuantityArray{T,N,D,Q}} = D
+dim_type(::Type{A}) where {T,N,D,Q,V,A<:QuantityArray{T,N,D,Q,V}} = D
+
 dim_type(A) = dim_type(typeof(A))
 
+# TODO: Can we avoid this pattern?
 value_type(::Type{A}) where {A<:QuantityArray} = DEFAULT_VALUE_TYPE
 value_type(::Type{A}) where {T,A<:QuantityArray{T}} = T
+value_type(::Type{A}) where {T,N,A<:QuantityArray{T,N}} = T
+value_type(::Type{A}) where {T,N,D,A<:QuantityArray{T,N,D}} = T
+value_type(::Type{A}) where {T,N,D,Q,A<:QuantityArray{T,N,D,Q}} = T
+value_type(::Type{A}) where {T,N,D,Q,V,A<:QuantityArray{T,N,D,Q,V}} = T
+
+value_type(::Type{Q}) where {Q<:AbstractQuantity} = DEFAULT_VALUE_TYPE
 value_type(::Type{Q}) where {T,Q<:AbstractQuantity{T}} = T
+value_type(::Type{Q}) where {T,D,Q<:AbstractQuantity{T,D}} = T
+
 value_type(A) = value_type(typeof(A))
 
 # One field:

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -83,29 +83,18 @@ end
 @inline ustrip(A::QuantityArray) = A.value
 @inline dimension(A::QuantityArray) = A.dimensions
 
-array_type(::Type{QuantityArray}) = Array{DEFAULT_VALUE_TYPE,N} where {N}
-array_type(::Type{QuantityArray{T}}) where {T} = Array{T,N} where {N}
-array_type(::Type{QuantityArray{T,N}}) where {T,N} = Array{T,N}
-array_type(::Type{QuantityArray{T,N,D}}) where {T,N,D} = Array{T,N}
-array_type(::Type{QuantityArray{T,N,D,Q}}) where {T,N,D,Q} = Array{T,N}
 array_type(::Type{<:QuantityArray{T,N,D,Q,V}}) where {T,N,D,Q,V} = V
-array_type(A) = array_type(typeof(A))
+array_type(A::QuantityArray) = array_type(typeof(A))
 
-quantity_type(::Type{QuantityArray}) = DEFAULT_QUANTITY_TYPE
-quantity_type(::Type{QuantityArray{T}}) where {T} = Quantity{T,DEFAULT_DIM_TYPE}
-quantity_type(::Type{QuantityArray{T,N}}) where {T,N} = Quantity{T,DEFAULT_DIM_TYPE}
-quantity_type(::Type{QuantityArray{T,N,D}}) where {T,N,D} = Quantity{T,D}
 quantity_type(::Type{<:QuantityArray{T,N,D,Q}}) where {T,N,D,Q} = Q
-quantity_type(A) = quantity_type(typeof(A))
+quantity_type(A::QuantityArray) = quantity_type(typeof(A))
 
-dim_type(::Type) = DEFAULT_DIM_TYPE
 dim_type(::Type{<:QuantityArray{T,N,D}}) where {T,N,D} = D
-dim_type(A) = dim_type(typeof(A))
+dim_type(A::QuantityArray) = dim_type(typeof(A))
 
 value_type(::Type{<:AbstractQuantity{T}}) where {T} = T
-value_type(::Type{QuantityArray}) = DEFAULT_VALUE_TYPE
 value_type(::Type{<:QuantityArray{T}}) where {T} = T
-value_type(A) = value_type(typeof(A))
+value_type(A::Union{<:QuantityArray,<:AbstractQuantity}) = value_type(typeof(A))
 
 # One field:
 for f in (:size, :length, :axes)

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -5,12 +5,12 @@ import Compat: allequal
 
 An array of quantities with value `value` of type `V` and dimensions `dimensions` of type `D`
 (which are shared across all elements of the array). This is a subtype of `AbstractArray{Q,N}`,
-and so can be used in most places where a normal array would be used.
+and so can be used in most places where a normal array would be used, including broadcasting operations.
 
 # Fields
 
-- `value`: The underlying array of values.
-- `dimensions`: The dimensions of the array.
+- `value`: The underlying array of values. Access with `ustrip(a)`.
+- `dimensions`: The dimensions of the array. Access with `dimension(a)`.
 
 # Constructors
 

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -164,11 +164,11 @@ materialize_first(q::AbstractArray{Q}, ::Any) where {Q<:AbstractQuantity} = firs
 # Derived calls
 materialize_first(r::Base.RefValue) = materialize_first(r.x)
 materialize_first(x::Base.Broadcast.Extruded) = materialize_first(x.x)
-materialize_first(args::Tuple) = materialize_first(first(args), Base.tail(args))
+materialize_first(args::Tuple) = materialize_first(first(args))
 materialize_first(args::AbstractArray) =
     let
         length(args) >= 1 || error("Unexpected broadcast format. Please submit a bug report.")
-        materialize_first(args[begin], args[begin+1:end])
+        materialize_first(args[begin])
     end
 materialize_first(::Tuple{}) = error("Unexpected broadcast format. Please submit a bug report.")
 materialize_first(::Any, rest) = materialize_first(rest)

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -177,6 +177,7 @@ end
 Base.hcat(A::QuantityArray...) = cat(A...; dims=2)
 Base.vcat(A::QuantityArray...) = cat(A...; dims=1)
 Base.fill(x::AbstractQuantity, dims::Dims...) = QuantityArray(fill(ustrip(x), dims...), dimension(x), typeof(x))
+Base.fill(x::AbstractQuantity, t::Tuple{}) = QuantityArray(fill(ustrip(x), t), dimension(x), typeof(x))
 
 ulength(q::QuantityArray) = ulength(dimension(q))
 umass(q::QuantityArray) = umass(dimension(q))

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -154,6 +154,7 @@ unwrap_quantity(::Type{T}) where {T} = T
 materialize_first(bc::Base.Broadcast.Broadcasted) = bc.f(materialize_first.(bc.args)...)
 
 # Base cases
+materialize_first(q::AbstractQuantity{<:AbstractArray}) = new_quantity(typeof(q), first(ustrip(q)), dimension(q))
 materialize_first(q::AbstractQuantity) = q
 materialize_first(q::QuantityArray) = first(q)
 materialize_first(q::AbstractArray{Q}) where {Q<:AbstractQuantity} = first(q)

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -131,7 +131,8 @@ function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{QA}}, ::Typ
                 * "the function you are broadcasting."
             )
         end
-        return QuantityArray(output_array, dimension(first_output), ElType)
+        first_output::ElType
+        return QuantityArray(output_array, dimension(first_output)::dim_type(ElType), ElType)
     else
         return output_array
     end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -48,8 +48,10 @@ function Base.promote_rule(::Type{QA1}, ::Type{QA2}) where {QA1<:QuantityArray,Q
     V = promote_type(array_type.((QA1, QA2))...)
     N = ndims(QA1)
 
-    @assert(Q <: AbstractQuantity{T,D}, "Incompatible promotion rules.")
-    @assert(V <: AbstractArray{T}, "Incompatible promotion rules.")
+    @assert(
+        Q <: AbstractQuantity{T,D} && V <: AbstractArray{T},
+        "Incompatible promotion rules between\n    $(QA1)\nand\n    $(QA2)\nPlease convert to a common quantity type first."
+    )
 
     if N != ndims(QA2)
         return QuantityArray{T,_N,D,Q,V} where {_N}

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -172,15 +172,14 @@ Base.show(io::IO, ::MIME"text/plain", ::Type{QA}) where {QA<:QuantityArray} = _p
 # Other array operations:
 Base.copy(A::QuantityArray) = QuantityArray(copy(ustrip(A)), copy(dimension(A)), quantity_type(A))
 for f in (:cat, :hcat, :vcat)
-    error_check = :(allequal(dimension.(A)) || throw(DimensionError(A[begin], A[begin+1:end])))
     if f == :cat
         @eval function Base.$f(A::QuantityArray...; dims)
-            $error_check
-            return QuantityArray($f(ustrip.(A)...; dims=dims), dimension(A[begin]), quantity_type(A[begin]))
+            allequal(dimension.(A)) || throw(DimensionError(A[begin], A[begin+1:end]))
+            return QuantityArray($f(ustrip.(A)...; dims), dimension(A[begin]), quantity_type(A[begin]))
         end
     else
         @eval function Base.$f(A::QuantityArray...)
-            $error_check
+            allequal(dimension.(A)) || throw(DimensionError(A[begin], A[begin+1:end]))
             return QuantityArray($f(ustrip.(A)...), dimension(A[begin]), quantity_type(A[begin]))
         end
     end

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -1,3 +1,5 @@
+import Compat: allequal
+
 """
     QuantityArray{T,N,D<:AbstractDimensions,Q<:AbstractQuantity,V<:AbstractArray}
 

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -65,10 +65,10 @@ function Base.promote_rule(::Type{QA1}, ::Type{QA2}) where {QA1<:QuantityArray,Q
     return QuantityArray{T,N,D,Q,V}
 end
 
+function Base.convert(::Type{QA}, A::QA) where {QA<:QuantityArray}
+    return A
+end
 function Base.convert(::Type{QA1}, A::QA2) where {QA1<:QuantityArray,QA2<:QuantityArray}
-    if A isa QA1
-        return A
-    end
     Q = quantity_type(QA1)
     V = array_type(QA1)
     N = ndims(QA1)

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -173,3 +173,11 @@ end
 Base.hcat(A::QuantityArray...) = cat(A...; dims=2)
 Base.vcat(A::QuantityArray...) = cat(A...; dims=1)
 Base.fill(x::AbstractQuantity, dims::Dims...) = QuantityArray(fill(ustrip(x), dims...), dimension(x), typeof(x))
+
+ulength(q::QuantityArray) = ulength(dimension(q))
+umass(q::QuantityArray) = umass(dimension(q))
+utime(q::QuantityArray) = utime(dimension(q))
+ucurrent(q::QuantityArray) = ucurrent(dimension(q))
+utemperature(q::QuantityArray) = utemperature(dimension(q))
+uluminosity(q::QuantityArray) = uluminosity(dimension(q))
+uamount(q::QuantityArray) = uamount(dimension(q))

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -155,11 +155,8 @@ materialize_first(bc::Base.Broadcast.Broadcasted) = bc.f(materialize_first.(bc.a
 
 # Base cases
 materialize_first(q::AbstractQuantity) = q
-materialize_first(q::AbstractQuantity, ::Any) = q
 materialize_first(q::QuantityArray) = first(q)
-materialize_first(q::QuantityArray, ::Any) = first(q)
 materialize_first(q::AbstractArray{Q}) where {Q<:AbstractQuantity} = first(q)
-materialize_first(q::AbstractArray{Q}, ::Any) where {Q<:AbstractQuantity} = first(q)
 
 # Derived calls
 materialize_first(r::Base.RefValue) = materialize_first(r.x)
@@ -171,7 +168,6 @@ materialize_first(args::AbstractArray) =
         materialize_first(args[begin])
     end
 materialize_first(::Tuple{}) = error("Unexpected broadcast format. Please submit a bug report.")
-materialize_first(::Any, rest) = materialize_first(rest)
 
 # Everything else:
 materialize_first(x) = x

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -148,15 +148,7 @@ end
 function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{QA}}, ::Type{ElType}) where {QA<:QuantityArray,ElType<:AbstractQuantity}
     T = value_type(ElType)
     output_array = similar(bc, T)
-    first_output = materialize_first(bc)
-    if typeof(first_output) != ElType
-        @warn (
-            "Materialization of first element likely failed. "
-            * "Please submit a bug report with information on "
-            * "the function you are broadcasting."
-        )
-    end
-    first_output::ElType
+    first_output::ElType = materialize_first(bc)
     return QuantityArray(output_array, dimension(first_output)::dim_type(ElType), ElType)
 end
 function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{QuantityArray{T,N,D,Q,V}}}, ::Type{ElType}) where {T,N,D,Q,V<:Array{T,N},ElType}

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -1,5 +1,3 @@
-const DEFAULT_QUANTITY_TYPE = Quantity
-
 """
     QuantityArray{T,N,D<:AbstractDimensions,Q<:AbstractQuantity,V<:AbstractArray}
 
@@ -38,7 +36,7 @@ end
 
 # Construct with a Quantity (easier, as you can use the units):
 QuantityArray(v::AbstractArray; kws...) = QuantityArray(v, DEFAULT_DIM_TYPE(; kws...))
-QuantityArray(v::AbstractArray, d::AbstractDimensions) = QuantityArray(v, d, DEFAULT_QUANTITY_TYPE)
+QuantityArray(v::AbstractArray, d::AbstractDimensions) = QuantityArray(v, d, Quantity)
 QuantityArray(v::AbstractArray, q::AbstractQuantity) = QuantityArray(v .* ustrip(q), dimension(q), typeof(q))
 QuantityArray(v::QA) where {Q<:AbstractQuantity,QA<:AbstractArray{Q}} = allequal(dimension.(v)) ? QuantityArray(ustrip.(v), dimension(first(v)), Q) : throw(DimensionError(first(v), v))
 # TODO: Should this check that the dimensions are the same?

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -167,7 +167,7 @@ Base.showarg(io::IO, v::QuantityArray, _) = _print_array_type(io, typeof(v))
 Base.show(io::IO, ::MIME"text/plain", ::Type{QA}) where {QA<:QuantityArray} = _print_array_type(io, QA)
 
 # Other array operations:
-Base.copy(A::QuantityArray) = QuantityArray(copy(ustrip(A)), dimension(A), quantity_type(A))
+Base.copy(A::QuantityArray) = QuantityArray(copy(ustrip(A)), copy(dimension(A)), quantity_type(A))
 function Base.cat(A::QuantityArray...; dims)
     allequal(dimension.(A)) || throw(DimensionError(A[begin], A[begin+1:end]))
     return QuantityArray(cat(ustrip.(A)...; dims=dims), dimension(A[begin]), quantity_type(A[begin]))

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -68,10 +68,18 @@ Base.round(::Type{T}, x::F) where {T,F<:FixedRational} = div(convert(T, x.num), 
 Base.decompose(x::F) where {T,F<:FixedRational{T}} = (x.num, zero(T), denom(F))
 
 # Promotion rules:
-Base.promote_rule(::Type{<:FixedRational{T1,den1}}, ::Type{<:FixedRational{T2,den2}}) where {T1,T2,den1,den2} = FixedRational{promote_type(T1,T2),den*den2}
-Base.promote_rule(::Type{<:FixedRational{T1,den}}, ::Type{<:FixedRational{T2,den}}) where {T1,T2,den} = FixedRational{promote_type(T1,T2),den}
-Base.promote_rule(::Type{<:FixedRational{T1}}, ::Type{Rational{T2}}) where {T1,T2} = Rational{promote_type(T1,T2)}
-Base.promote_rule(::Type{<:FixedRational{T1}}, ::Type{T2}) where {T1,T2} = promote_type(Rational{T1}, T2)
+function Base.promote_rule(::Type{<:FixedRational{T1,den1}}, ::Type{<:FixedRational{T2,den2}}) where {T1,T2,den1,den2}
+    return error("Refusing to promote `FixedRational` types with mixed denominators. Use `Rational` instead.")
+end
+function Base.promote_rule(::Type{<:FixedRational{T1,den}}, ::Type{<:FixedRational{T2,den}}) where {T1,T2,den}
+    return FixedRational{promote_type(T1,T2),den}
+end
+function Base.promote_rule(::Type{<:FixedRational{T1}}, ::Type{Rational{T2}}) where {T1,T2}
+    return Rational{promote_type(T1,T2)}
+end
+function Base.promote_rule(::Type{<:FixedRational{T1}}, ::Type{T2}) where {T1,T2}
+    return promote_type(Rational{T1}, T2)
+end
 
 # Want to consume integers:
 Base.promote(x::Integer, y::F) where {F<:FixedRational} = (F(x), y)

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -48,11 +48,10 @@ Base.inv(x::F) where {F<:FixedRational} = unsafe_fixed_rational(widemul(denom(F)
 Base.:*(l::F, r::Integer) where {F<:FixedRational} = unsafe_fixed_rational(l.num * r, eltype(F), val_denom(F))
 Base.:*(l::Integer, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l * r.num, eltype(F), val_denom(F))
 
-Base.:(==)(x::F, y::F) where {F<:FixedRational} = x.num == y.num
-Base.isless(x::F, y::F) where {F<:FixedRational} = isless(x.num, y.num)
-Base.:<(x::F, y::F) where {F<:FixedRational} = x.num < y.num
-Base.:<=(x::F, y::F) where {F<:FixedRational} = x.num <= y.num
-Base.isapprox(x::F, y::F; kws...) where {F<:FixedRational} = isapprox(x.num, y.num; kws...)
+for comp in (:(==), :isequal, :<, :(isless), :<=)
+    @eval Base.$comp(x::F, y::F) where {F<:FixedRational} = $comp(x.num, y.num)
+end
+
 Base.iszero(x::FixedRational) = iszero(x.num)
 Base.isone(x::F) where {F<:FixedRational} = x.num == denom(F)
 Base.isinteger(x::F) where {F<:FixedRational} = iszero(x.num % denom(F))

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -63,7 +63,7 @@ Base.convert(::Type{AF}, x::F) where {AF<:AbstractFloat,F<:FixedRational} = conv
 Base.convert(::Type{I}, x::F) where {I<:Integer,F<:FixedRational} =
     let
         isinteger(x) || throw(InexactError(:convert, I, x))
-        div(x.num, denom(F))
+        convert(I, div(x.num, denom(F)))
     end
 Base.round(::Type{T}, x::F) where {T,F<:FixedRational} = div(convert(T, x.num), convert(T, denom(F)), RoundNearest)
 Base.decompose(x::F) where {T,F<:FixedRational{T}} = (x.num, zero(T), denom(F))

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -37,9 +37,6 @@ const DEFAULT_DENOM = DEFAULT_NUMERATOR_TYPE(2^4 * 3^2 * 5^2 * 7)
 (::Type{F})(x::Rational) where {F<:FixedRational} = unsafe_fixed_rational(widemul(x.num, denom(F)) ÷ x.den, eltype(F), val_denom(F))
 
 Base.:*(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(widemul(l.num, r.num) ÷ denom(F), eltype(F), val_denom(F))
-Base.:*(l::Integer, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l * r.num, eltype(F), val_denom(F))
-Base.:*(l::F, r::Integer) where {F<:FixedRational} = unsafe_fixed_rational(l.num * r, eltype(F), val_denom(F))
-
 Base.:+(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l.num + r.num, eltype(F), val_denom(F))
 Base.:-(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l.num - r.num, eltype(F), val_denom(F))
 Base.:-(x::F) where {F<:FixedRational} = unsafe_fixed_rational(-x.num, eltype(F), val_denom(F))

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -55,7 +55,11 @@ Base.convert(::Type{F}, x::Rational) where {F<:FixedRational} = F(x)
 Base.convert(::Type{Rational{R}}, x::F) where {R,F<:FixedRational} = Rational{R}(x.num, denom(F))
 Base.convert(::Type{Rational}, x::F) where {F<:FixedRational} = Rational{eltype(F)}(x.num, denom(F))
 Base.convert(::Type{AF}, x::F) where {AF<:AbstractFloat,F<:FixedRational} = convert(AF, x.num) / convert(AF, denom(F))
-Base.convert(::Type{I}, x::F) where {I<:Integer,F<:FixedRational} = isinteger(x) ? div(x.num, denom(F)) : throw(InexactError(:convert, I, x))
+Base.convert(::Type{I}, x::F) where {I<:Integer,F<:FixedRational} =
+    let
+        isinteger(x) || throw(InexactError(:convert, I, x))
+        div(x.num, denom(F))
+    end
 Base.round(::Type{T}, x::F) where {T,F<:FixedRational} = div(convert(T, x.num), convert(T, denom(F)), RoundNearest)
 Base.decompose(x::F) where {T,F<:FixedRational{T}} = (x.num, zero(T), denom(F))
 

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -37,9 +37,13 @@ const DEFAULT_DENOM = DEFAULT_NUMERATOR_TYPE(2^4 * 3^2 * 5^2 * 7)
 (::Type{F})(x::Rational) where {F<:FixedRational} = unsafe_fixed_rational(widemul(x.num, denom(F)) ÷ x.den, eltype(F), val_denom(F))
 
 Base.:*(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(widemul(l.num, r.num) ÷ denom(F), eltype(F), val_denom(F))
+Base.:*(l::Integer, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l * r.num, eltype(F), val_denom(F))
+Base.:*(l::F, r::Integer) where {F<:FixedRational} = unsafe_fixed_rational(l.num * r, eltype(F), val_denom(F))
+
 Base.:+(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l.num + r.num, eltype(F), val_denom(F))
 Base.:-(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l.num - r.num, eltype(F), val_denom(F))
 Base.:-(x::F) where {F<:FixedRational} = unsafe_fixed_rational(-x.num, eltype(F), val_denom(F))
+
 Base.inv(x::F) where {F<:FixedRational} = unsafe_fixed_rational(widemul(denom(F), denom(F)) ÷ x.num, eltype(F), val_denom(F))
 
 Base.:(==)(x::F, y::F) where {F<:FixedRational} = x.num == y.num

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -33,6 +33,8 @@ Base.eltype(::Type{F}) where {T,F<:FixedRational{T}} = T
 const DEFAULT_NUMERATOR_TYPE = Int32
 const DEFAULT_DENOM = DEFAULT_NUMERATOR_TYPE(2^4 * 3^2 * 5^2 * 7)
 
+(::Type{F})(x::F) where {F<:FixedRational} = x
+(::Type{F})(x::F2) where {T,T2,den,F<:FixedRational{T,den},F2<:FixedRational{T2,den}} = unsafe_fixed_rational(x.num, eltype(F), val_denom(F))
 (::Type{F})(x::Integer) where {F<:FixedRational} = unsafe_fixed_rational(x * denom(F), eltype(F), val_denom(F))
 (::Type{F})(x::Rational) where {F<:FixedRational} = unsafe_fixed_rational(widemul(x.num, denom(F)) ÷ x.den, eltype(F), val_denom(F))
 
@@ -84,7 +86,6 @@ end
 # Want to consume integers:
 Base.promote(x::Integer, y::F) where {F<:FixedRational} = (F(x), y)
 Base.promote(x::F, y::Integer) where {F<:FixedRational} = reverse(promote(y, x))
-Base.promote(x::F1, y::F2) where {F1<:FixedRational,F2<:FixedRational} = (@assert denom(F1) == denom(F2); (x, y))
 
 Base.string(x::FixedRational) =
     let

--- a/src/math.jl
+++ b/src/math.jl
@@ -38,9 +38,12 @@ Base.:-(l::AbstractQuantity, r) = l + (-r)
 Base.:-(l, r::AbstractQuantity) = l + (-r)
 
 # We don't promote on the dimension types:
-_pow(l::AbstractDimensions{R}, r::R) where {R} = map_dimensions(Base.Fix1(*, r), l)
-Base.:^(l::AbstractDimensions{R}, r::Integer) where {R<:FixedRational} = map_dimensions(Base.Fix1(*, r), l)
-Base.:^(l::AbstractDimensions{R}, r::Number) where {R} = _pow(l, tryrationalize(R, r))
+function Base.:^(l::AbstractDimensions{R}, r::Integer) where {R}
+    return map_dimensions(Base.Fix1(*, r), l)
+end
+function Base.:^(l::AbstractDimensions{R}, r::Number) where {R}
+    return map_dimensions(Base.Fix1(*, tryrationalize(R, r)), l)
+end
 # Special forms for small integer powers (will unroll dimension multiplication into repeated additions)
 # https://github.com/JuliaLang/julia/blob/b99f251e86c7c09b957a1b362b6408dbba106ff0/base/intfuncs.jl#L332
 for (p, ex) in [
@@ -54,12 +57,15 @@ for (p, ex) in [
     @eval @inline Base.literal_pow(::typeof(^), l::AbstractDimensions, ::Val{$p}) = $ex
 end
 
-Base.:^(l::AbstractQuantity{T,D}, r::Integer) where {T,R,D<:AbstractDimensions{R}} = new_quantity(typeof(l), ustrip(l)^r, dimension(l)^r)
-Base.:^(l::AbstractQuantity{T,D}, r::Number) where {T,R,D<:AbstractDimensions{R}} =
-    let dim_pow = tryrationalize(R, r), val_pow = convert(T, dim_pow)
-        # Need to ensure we take the numerical power by the rationalized quantity:
-        return new_quantity(typeof(l), ustrip(l)^val_pow, dimension(l)^dim_pow)
-    end
+function Base.:^(l::AbstractQuantity{T,D}, r::Integer) where {T,R,D<:AbstractDimensions{R}}
+    return new_quantity(typeof(l), ustrip(l)^r, dimension(l)^r)
+end
+function Base.:^(l::AbstractQuantity{T,D}, r::Number) where {T,R,D<:AbstractDimensions{R}}
+    dim_pow = tryrationalize(R, r)
+    val_pow = convert(T, dim_pow)
+    # Need to ensure we take the numerical power by the rationalized quantity:
+    return new_quantity(typeof(l), ustrip(l)^val_pow, dimension(l)^dim_pow)
+end
 @inline Base.literal_pow(::typeof(^), l::AbstractDimensions, ::Val{p}) where {p} = map_dimensions(Base.Fix1(*, p), l)
 @inline Base.literal_pow(::typeof(^), l::AbstractQuantity, ::Val{p}) where {p} = new_quantity(typeof(l), Base.literal_pow(^, ustrip(l), Val(p)), Base.literal_pow(^, dimension(l), Val(p)))
 

--- a/src/math.jl
+++ b/src/math.jl
@@ -39,6 +39,7 @@ Base.:-(l, r::AbstractQuantity) = l + (-r)
 
 # We don't promote on the dimension types:
 _pow(l::AbstractDimensions{R}, r::R) where {R} = map_dimensions(Base.Fix1(*, r), l)
+Base.:^(l::AbstractDimensions{R}, r::Integer) where {R<:FixedRational} = map_dimensions(Base.Fix1(*, r), l)
 Base.:^(l::AbstractDimensions{R}, r::Number) where {R} = _pow(l, tryrationalize(R, r))
 Base.:^(l::AbstractQuantity{T,D}, r::Integer) where {T,R,D<:AbstractDimensions{R}} = new_quantity(typeof(l), ustrip(l)^r, dimension(l)^r)
 Base.:^(l::AbstractQuantity{T,D}, r::Number) where {T,R,D<:AbstractDimensions{R}} =

--- a/src/math.jl
+++ b/src/math.jl
@@ -16,12 +16,24 @@ Base.:/(l, r::AbstractQuantity) = l * inv(r)
 Base.:/(l::AbstractDimensions, r) = error("Please use an `AbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
 Base.:/(l, r::AbstractDimensions) = error("Please use an `AbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
 
-Base.:+(l::AbstractQuantity, r::AbstractQuantity) = dimension(l) == dimension(r) ? new_quantity(typeof(l), ustrip(l) + ustrip(r), dimension(l)) : throw(DimensionError(l, r))
+Base.:+(l::AbstractQuantity, r::AbstractQuantity) =
+    let
+        dimension(l) == dimension(r) || throw(DimensionError(l, r))
+        new_quantity(typeof(l), ustrip(l) + ustrip(r), dimension(l))
+    end
 Base.:-(l::AbstractQuantity) = new_quantity(typeof(l), -ustrip(l), dimension(l))
 Base.:-(l::AbstractQuantity, r::AbstractQuantity) = l + (-r)
 
-Base.:+(l::AbstractQuantity, r) = iszero(dimension(l)) ? new_quantity(typeof(l), ustrip(l) + r, dimension(l)) : throw(DimensionError(l, r))
-Base.:+(l, r::AbstractQuantity) = iszero(dimension(r)) ? new_quantity(typeof(r), l + ustrip(r), dimension(r)) : throw(DimensionError(l, r))
+Base.:+(l::AbstractQuantity, r) =
+    let
+        iszero(dimension(l)) || throw(DimensionError(l, r))
+        new_quantity(typeof(l), ustrip(l) + r, dimension(l))
+    end
+Base.:+(l, r::AbstractQuantity) =
+    let
+        iszero(dimension(r)) || throw(DimensionError(l, r))
+        new_quantity(typeof(r), l + ustrip(r), dimension(r))
+    end
 Base.:-(l::AbstractQuantity, r) = l + (-r)
 Base.:-(l, r::AbstractQuantity) = l + (-r)
 

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -101,7 +101,6 @@ Base.iszero(d::SymbolicDimensions) = iszero(data(d))
 Base.:*(l::SymbolicDimensions, r::SymbolicDimensions) = SymbolicDimensions(data(l) + data(r))
 Base.:/(l::SymbolicDimensions, r::SymbolicDimensions) = SymbolicDimensions(data(l) - data(r))
 Base.inv(d::SymbolicDimensions) = SymbolicDimensions(-data(d))
-Base.:^(l::SymbolicDimensions{R}, r::R) where {R} = SymbolicDimensions(data(l) * r)
 Base.:^(l::SymbolicDimensions{R}, r::Integer) where {R} = SymbolicDimensions(data(l) * r)
 Base.:^(l::SymbolicDimensions{R}, r::Number) where {R} = SymbolicDimensions(data(l) * tryrationalize(R, r))
 

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -92,6 +92,7 @@ to one with `Dimensions`.
 function expand_units(q::Q) where {T,R,D<:SymbolicDimensions{R},Q<:AbstractQuantity{T,D}}
     return convert(constructor_of(Q){T,Dimensions{R}}, q)
 end
+expand_units(q::QuantityArray) = expand_units.(q)
 
 
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(data(d)))

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -101,7 +101,9 @@ Base.iszero(d::SymbolicDimensions) = iszero(data(d))
 Base.:*(l::SymbolicDimensions, r::SymbolicDimensions) = SymbolicDimensions(data(l) + data(r))
 Base.:/(l::SymbolicDimensions, r::SymbolicDimensions) = SymbolicDimensions(data(l) - data(r))
 Base.inv(d::SymbolicDimensions) = SymbolicDimensions(-data(d))
-_pow(l::SymbolicDimensions{R}, r::R) where {R} = SymbolicDimensions(data(l) * r)
+Base.:^(l::SymbolicDimensions{R}, r::R) where {R} = SymbolicDimensions(data(l) * r)
+Base.:^(l::SymbolicDimensions{R}, r::Integer) where {R} = SymbolicDimensions(data(l) * r)
+Base.:^(l::SymbolicDimensions{R}, r::Number) where {R} = SymbolicDimensions(data(l) * tryrationalize(R, r))
 
 
 """

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -89,8 +89,8 @@ Expand the symbolic units in a quantity to their base SI form.
 In other words, this converts a `Quantity` with `SymbolicDimensions`
 to one with `Dimensions`.
 """
-function expand_units(q::Q) where {T,R,D<:SymbolicDimensions{R},Q<:Quantity{T,D}}
-    return convert(Quantity{T,Dimensions{R}}, q)
+function expand_units(q::Q) where {T,R,D<:SymbolicDimensions{R},Q<:AbstractQuantity{T,D}}
+    return convert(constructor_of(Q){T,Dimensions{R}}, q)
 end
 
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -39,9 +39,12 @@ Base.keys(d::AbstractDimensions) = static_fieldnames(typeof(d))
 Base.getindex(d::AbstractDimensions, k::Symbol) = getfield(d, k)
 
 # Compatibility with `.*`
-Base.length(::AbstractQuantity) = 1
-Base.iterate(qd::AbstractQuantity) = (qd, nothing)
-Base.iterate(::AbstractQuantity, ::Nothing) = nothing
+Base.length(q::AbstractQuantity) = length(ustrip(q))
+Base.iterate(qd::AbstractQuantity, maybe_state...) = 
+    let subiterate=iterate(ustrip(qd), maybe_state...)
+        subiterate === nothing && return nothing
+        return new_quantity(typeof(qd), subiterate[1], dimension(qd)), subiterate[2]
+    end
 
 # Numeric checks
 Base.isapprox(l::AbstractQuantity, r::AbstractQuantity; kws...) = isapprox(ustrip(l), ustrip(r); kws...) && dimension(l) == dimension(r)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -39,7 +39,9 @@ Base.keys(d::AbstractDimensions) = static_fieldnames(typeof(d))
 Base.getindex(d::AbstractDimensions, k::Symbol) = getfield(d, k)
 
 # Compatibility with `.*`
+Base.size(q::AbstractQuantity) = size(ustrip(q))
 Base.length(q::AbstractQuantity) = length(ustrip(q))
+Base.axes(q::AbstractQuantity) = axes(ustrip(q))
 Base.iterate(qd::AbstractQuantity, maybe_state...) =
     let subiterate=iterate(ustrip(qd), maybe_state...)
         subiterate === nothing && return nothing
@@ -47,6 +49,10 @@ Base.iterate(qd::AbstractQuantity, maybe_state...) =
     end
 Base.ndims(::Type{<:AbstractQuantity{T}}) where {T} = ndims(T)
 Base.ndims(q::AbstractQuantity) = ndims(ustrip(q))
+Base.broadcastable(q::AbstractQuantity) = new_quantity(typeof(q), Base.broadcastable(ustrip(q)), dimension(q))
+Base.getindex(q::AbstractQuantity, i...) = new_quantity(typeof(q), getindex(ustrip(q), i...), dimension(q))
+Base.keys(q::AbstractQuantity) = keys(ustrip(q))
+
 
 # Numeric checks
 function Base.isapprox(l::AbstractQuantity, r::AbstractQuantity; kws...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -183,6 +183,7 @@ Base.convert(::Type{Q}, q::AbstractQuantity) where {T,D,Q<:AbstractQuantity{T,D}
 Base.convert(::Type{D}, d::AbstractDimensions) where {D<:AbstractDimensions} = d
 Base.convert(::Type{D}, d::AbstractDimensions) where {R,D<:AbstractDimensions{R}} = D(d)
 
+Base.copy(d::D) where {D<:AbstractDimensions} = map_dimensions(copy, d)
 Base.copy(q::Q) where {Q<:AbstractQuantity} = new_quantity(Q, copy(ustrip(q)), copy(dimension(q)))
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -45,6 +45,8 @@ Base.iterate(qd::AbstractQuantity, maybe_state...) =
         subiterate === nothing && return nothing
         return new_quantity(typeof(qd), subiterate[1], dimension(qd)), subiterate[2]
     end
+Base.ndims(::Type{<:AbstractQuantity{T}}) where {T} = ndims(T)
+Base.ndims(q::AbstractQuantity) = ndims(ustrip(q))
 
 # Numeric checks
 function Base.isapprox(l::AbstractQuantity, r::AbstractQuantity; kws...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,4 @@
 import Tricks: static_fieldnames
-import LinearAlgebra: norm
 import Compat: allequal
 
 function map_dimensions(f::F, args::AbstractDimensions...) where {F<:Function}
@@ -78,8 +77,6 @@ for f in (:iszero, :isfinite, :isinf, :isnan, :isreal)
 end
 
 # Simple operations which return a full quantity (same dimensions)
-norm(q::AbstractQuantity, p::Real=2) = new_quantity(typeof(q), norm(ustrip(q), p), dimension(q))
-norm(q::AbstractArray{<:AbstractQuantity}, p::Real=2) = new_quantity(eltype(q), norm(ustrip(q), p), dimension(q))
 for f in (:real, :imag, :conj, :adjoint, :unsigned, :nextfloat, :prevfloat)
     @eval Base.$f(q::AbstractQuantity) = new_quantity(typeof(q), $f(ustrip(q)), dimension(q))
 end

--- a/test/test_scitypes.jl
+++ b/test/test_scitypes.jl
@@ -21,4 +21,4 @@ sch = schema(X)
 @test first(sch.scitypes) == Continuous
 @test first(sch.types) <: Quantity{Float64}
 
-@test first(schema((; x=rand(1:10) .* Quantity{Int}(u"m/s"))).scitypes) == Count
+@test first(schema((; x=rand(1:10, 5) .* Quantity{Int}(u"m/s"))).scitypes) == Count

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -540,6 +540,8 @@ end
 
     @testset "Utilities" begin
         @test fill(u"m/s", 10) == QuantityArray(fill(1.0, 10) .* u"m/s")
+        @test ndims(fill(u"m/s", ())) == 0
+        @test fill(u"m/s", ())[begin] == u"m/s"
     end
 
     @testset "Generic literal_pow" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -408,6 +408,10 @@ end
     @test promote(f64, f8) == (2, 2)
     @test typeof(promote(f64, f8)) == typeof((f64, f64))
     @test typeof(promote(FixedRational{Int8,10}(2), FixedRational{Int8,10}(2))) == typeof((f8, f8))
+
+    # Required to hit integer branch (otherwise will go to `literal_pow`)
+    f(i::Int) = Dimensions(length=1, mass=-1)^i
+    @test f(2) == Dimensions(length=2, mass=-2)
 end
 
 @testset "Quantity promotion" begin
@@ -535,6 +539,10 @@ end
     @testset "Basics" begin
         x = QuantityArray(randn(32), u"km/s")
         @test ustrip(sum(x)) == sum(ustrip(x))
+
+        # Setting index with different quantity:
+        x[5] = Quantity(5, length=1, time=-1)
+        @test x[5] == Quantity(5, length=1, time=-1)
 
         y = randn(32)
         @test ustrip(QuantityArray(y, u"m")) == y
@@ -676,5 +684,10 @@ end
         Base.showarg(io, z, true)
         msg = String(take!(io))
         @test msg == "QuantityArray(::Vector{Float64}, ::DynamicQuantities.Quantity{Float64, DynamicQuantities.SymbolicDimensions{DynamicQuantities.FixedRational{Int32, 25200}}})"
+
+        io = IOBuffer()
+        Base.show(io, typeof(z))
+        msg2 = String(take!(io))
+        @test msg2 == msg
     end
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -413,6 +413,21 @@ end
     # Required to hit integer branch (otherwise will go to `literal_pow`)
     f(i::Int) = Dimensions(length=1, mass=-1)^i
     @test f(2) == Dimensions(length=2, mass=-2)
+
+    # Null conversion
+    @test typeof(FixedRational{Int,10}(FixedRational{Int,10}(2))) == FixedRational{Int,10}
+
+    # Conversion to Rational without specifying type
+    @test convert(Rational, FixedRational{UInt8,6}(2)) === Rational{UInt8}(2)
+
+    # Showing rationals
+    function show_string(i)
+        io = IOBuffer()
+        show(io, i)
+        return String(take!(io))
+    end
+    @test show_string(FixedRational{Int,10}(2)) == "2"
+    @test show_string(FixedRational{Int,10}(11//10)) == "11//10"
 end
 
 @testset "Quantity promotion" begin
@@ -514,6 +529,9 @@ end
     # So the numerical value is different from other constants:
     @test ustrip(us"Constants.h") == ustrip(u"Constants.h")
     @test ustrip(us"Constants.au") != ustrip(u"Constants.au")
+
+    # Test conversion
+    @test typeof(SymbolicDimensions{Rational{Int}}(dimension(us"km/s"))) == SymbolicDimensions{Rational{Int}}
 end
 
 @testset "Test ambiguities" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -735,6 +735,13 @@ end
         z = rand(1:10, 32)
         w = Quantity{Float32}(u"m/s")
         @test typeof(g(x, y, z, w)) <: QuantityArray{Float64}
+
+        y32 = QuantityArray(ustrip(y), dimension(y))
+        @test typeof(y .* y32) <: QuantityArray{Float64}
+
+        a = [randn() * u"km/s" for i=1:32]
+        @test typeof(y .* a) <: QuantityArray
+        @test typeof(a .* y) <: QuantityArray
     end
 
     @testset "Broadcast scalars" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -491,6 +491,10 @@ end
     @test dimension(inv(us"s") * us"m") != dimension(us"km/s")
     @test dimension(expand_units(inv(us"s") * us"m")) == dimension(expand_units(us"km/s"))
 
+    f2(i::Int) = us"s"^i
+    @inferred f2(5)
+    @test expand_units(f2(5)) == u"s"^5
+
     @test_throws ErrorException sym_uparse("'c'")
 
     # For constants which have a namespace collision, the numerical expansion is used:
@@ -561,6 +565,7 @@ end
         @test QuantityArray(ones(3), u"m/s") == QuantityArray(ones(3), length=1, time=-1)
 
         fv(v) = f.(v)
+        fv(y_q)
         @inferred fv(y_q)
 
         # Same array type:

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1,6 +1,7 @@
 using DynamicQuantities
 using DynamicQuantities: FixedRational
 using DynamicQuantities: DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
+using DynamicQuantities: array_type
 using Ratios: SimpleRatio
 using SaferIntegers: SafeInt16
 using StaticArrays: SArray, MArray
@@ -551,30 +552,29 @@ end
         y = randn(32)
         @test ustrip(QuantityArray(y, u"m")) == y
 
-        f(v) = v^2 * 1.5 - v^2
-        @test sum(f.(QuantityArray(y, u"m"))) == sum(f.(y) .* u"m^2")
+        f_square(v) = v^2 * 1.5 - v^2
+        @test sum(f_square.(QuantityArray(y, u"m"))) == sum(f_square.(y) .* u"m^2")
 
         y_q = QuantityArray(y, u"m * cd / s")
-        @test typeof(f.(y_q)) == typeof(y_q)
+        @test typeof(f_square.(y_q)) == typeof(y_q)
 
         for get_u in (ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount)
-            @test get_u(f.(y_q)) == get_u(y_q) * 2
-            @test get_u(f(first(y_q))) == get_u(y_q) * 2
+            @test get_u(f_square.(y_q)) == get_u(y_q) * 2
+            @test get_u(f_square(first(y_q))) == get_u(y_q) * 2
         end
 
         @test QuantityArray(ones(3), u"m/s") == QuantityArray(ones(3), length=1, time=-1)
 
-        fv(v) = f.(v)
-        fv(y_q)
-        @inferred fv(y_q)
+        fv_square(v) = f_square.(v)
+        @inferred fv_square(y_q)
 
         # Same array type:
         s_x = QuantityArray(SArray{Tuple{32}}(ustrip(x)), dimension(x))
         output_s_x = (xi -> xi^2).(s_x)
         @test array_type(output_s_x) <: MArray
         @test dimension(output_s_x) == dimension(x)^2
-        f(x) = (xi -> xi^2).(x)
-        @inferred f(s_x)
+        fv_square2(x) = (xi -> xi^2).(x)
+        @inferred fv_square2(s_x)
     end
 
     @testset "Utilities" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -428,6 +428,11 @@ end
     end
     @test show_string(FixedRational{Int,10}(2)) == "2"
     @test show_string(FixedRational{Int,10}(11//10)) == "11//10"
+
+    # Promotion rules
+    @test promote_type(FixedRational{Int64,10},FixedRational{BigInt,10}) == FixedRational{BigInt,10}
+    @test promote_type(Rational{Int8}, FixedRational{Int,12345}) == Rational{Int}
+    @test promote_type(Int8, FixedRational{Int,12345}) == promote_type(Int8, Rational{Int})
 end
 
 @testset "Quantity promotion" begin
@@ -541,6 +546,7 @@ end
     @test promote(x, y) == (x, y)
     @test_throws ErrorException promote(x, convert(FixedRational{Int32,100}, 10))
     @test round(Missing, x) === missing
+    @test promote_type(typeof(u"km/s"), typeof(convert(Quantity{Float32}, u"km/s"))) <: Quantity{Float64}
 
     x = 1.0u"m"
     y = missing
@@ -669,6 +675,7 @@ end
         expected_D = Dimensions{Rational{Int64}}
         expected_type = QuantityArray{expected_T,1,expected_D,Quantity{Float64,expected_D},Array{expected_T,1}}
 
+        @test promote_type(typeof(qarr1), typeof(qarr2)) == expected_type
         @test typeof(promote(qarr1, qarr2)) == Tuple{expected_type, expected_type}
     end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -742,6 +742,14 @@ end
         a = [randn() * u"km/s" for i=1:32]
         @test typeof(y .* a) <: QuantityArray
         @test typeof(a .* y) <: QuantityArray
+
+        b = Quantity(randn(Float32, 32)) * u"km/s"
+        @test typeof(b) <: Quantity
+        @test typeof(b .* b) <: Vector{<:Quantity}
+        @test typeof(a .* b) <: Vector{<:Quantity}
+        @test typeof(b .* a) <: Vector{<:Quantity}
+        @test typeof(y .* b) <: QuantityArray{Float64}
+        @test typeof(b .* y) <: QuantityArray{Float64}
     end
 
     @testset "Broadcast scalars" begin
@@ -772,5 +780,17 @@ end
         Base.show(io, MIME"text/plain"(), typeof(z))
         msg2 = String(take!(io))
         @test msg2 == msg
+    end
+
+    @testset "Extra test coverage" begin
+        @test_throws ErrorException DynamicQuantities.materialize_first(())
+        VERSION >= v"1.8" &&
+            @test_throws "Unexpected broadcast" DynamicQuantities.materialize_first(())
+
+        # Not sure how to test this otherwise, but method is supposed to be
+        # required for the broadcasting interface
+        x = [1u"km/s"]
+        ref = Base.RefValue(x)
+        @test DynamicQuantities.materialize_first(ref) === x[1]
     end
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -559,6 +559,17 @@ end
         @test fill(u"m/s", ())[begin] == u"m/s"
     end
 
+    @testset "Promotion" begin
+        qarr1 = QuantityArray(randn(32), convert(Dimensions{Rational{Int32}}, dimension(u"km/s")))
+        qarr2 = QuantityArray(randn(Float16, 32), convert(Dimensions{Rational{Int64}}, dimension(u"km/s")))
+
+        expected_T = Float64
+        expected_D = Dimensions{Rational{Int64}}
+        expected_type = QuantityArray{expected_T,1,expected_D,Quantity{Float64,expected_D},Array{expected_T,1}}
+
+        @test typeof(promote(qarr1, qarr2)) == Tuple{expected_type, expected_type}
+    end
+
     @testset "Generic literal_pow" begin
         y = randn(32)
         y_q = QuantityArray(y, u"m")

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -577,6 +577,14 @@ end
         @inferred fv_square2(s_x)
     end
 
+    @testset "Copying" begin
+        x = QuantityArray(randn(3), u"km/s")
+        xc = copy(x)
+        @test x == xc
+        xc[2] *= 0.5
+        @test x != xc
+    end
+
     @testset "Utilities" begin
         @test fill(u"m/s", 10) == QuantityArray(fill(1.0, 10) .* u"m/s")
         @test ndims(fill(u"m/s", ())) == 0

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -464,6 +464,8 @@ end
     @test typeof(f.(y_q)) == typeof(y_q)
     @test ulength(f.(y_q)) == ulength(y_q) * 2
 
+    @test fill(u"m/s", 10) == QuantityArray(fill(1.0, 10) .* u"m/s")
+
     @testset "Symbolic units" begin
         z_ar = randn(32)
         z = QuantityArray(z_ar, us"Constants.h * km/s")
@@ -472,6 +474,6 @@ end
         io = IOBuffer()
         Base.showarg(io, z, true)
         msg = String(take!(io))
-        @test msg == "QuantityArray(::Vector{Float64}, ::Quantity{Float64, SymbolicDimensions{DynamicQuantities.FixedRational{Int32, 25200}}})"
+        @test msg == "QuantityArray(::Vector{Float64}, ::DynamicQuantities.Quantity{Float64, DynamicQuantities.SymbolicDimensions{DynamicQuantities.FixedRational{Int32, 25200}}})"
     end
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -469,8 +469,9 @@ end
     @testset "Symbolic units" begin
         z_ar = randn(32)
         z = QuantityArray(z_ar, us"Constants.h * km/s")
-        z_true = z_ar .* u"Constants.h * km/s"
-        @test all(expand_units.(z) .≈ z_true)
+        z_expanded = QuantityArray(z_ar .* u"Constants.h * km/s")
+        @test typeof(expand_units(z)) == typeof(z_expanded)
+        @test all(expand_units(z) .≈ z_expanded)
         io = IOBuffer()
         Base.showarg(io, z, true)
         msg = String(take!(io))

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -3,6 +3,7 @@ using DynamicQuantities: FixedRational
 using DynamicQuantities: DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
 using Ratios: SimpleRatio
 using SaferIntegers: SafeInt16
+using StaticArrays: SArray
 using LinearAlgebra: norm
 using Test
 
@@ -568,6 +569,29 @@ end
         expected_type = QuantityArray{expected_T,1,expected_D,Quantity{Float64,expected_D},Array{expected_T,1}}
 
         @test typeof(promote(qarr1, qarr2)) == Tuple{expected_type, expected_type}
+    end
+
+    @testset "Array concatenation" begin
+        qarr1 = QuantityArray(randn(3) .* u"km/s")
+        qarr2 = QuantityArray(randn(3) .* u"km/s")
+
+        @test ustrip.(hcat(qarr1, qarr2)) == hcat(ustrip(qarr1), ustrip(qarr2))
+        @test ustrip.(vcat(qarr1, qarr2)) == vcat(ustrip(qarr1), ustrip(qarr2))
+        @test ustrip.(cat(qarr1, qarr2, dims=2)) == cat(ustrip(qarr1), ustrip(qarr2), dims=Val(2))
+        @test dimension(hcat(qarr1, qarr2)) == dimension(u"km/s")
+        
+        # type stability:
+        @inferred hcat(qarr1, qarr2)
+        @inferred vcat(qarr1, qarr2)
+        @inferred cat(qarr1, qarr2, dims=2)
+
+        # same array type:
+        s_qarr1 = QuantityArray(SArray{Tuple{3}}(ustrip(qarr1)), dimension(qarr1))
+        s_qarr2 = QuantityArray(SArray{Tuple{3}}(ustrip(qarr2)), dimension(qarr2))
+        @test array_type(hcat(s_qarr1, s_qarr2)) <: SArray
+
+        # Test concatenating different arrays:
+
     end
 
     @testset "Generic literal_pow" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -3,7 +3,7 @@ using DynamicQuantities: FixedRational
 using DynamicQuantities: DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
 using Ratios: SimpleRatio
 using SaferIntegers: SafeInt16
-using StaticArrays: SArray
+using StaticArrays: SArray, MArray
 using LinearAlgebra: norm
 using Test
 
@@ -550,8 +550,18 @@ end
             @test get_u(f(first(y_q))) == get_u(y_q) * 2
         end
 
+        @test QuantityArray(ones(3), u"m/s") == QuantityArray(ones(3), length=1, time=-1)
+
         fv(v) = f.(v)
         @inferred fv(y_q)
+
+        # Same array type:
+        s_x = QuantityArray(SArray{Tuple{32}}(ustrip(x)), dimension(x))
+        output_s_x = (xi -> xi^2).(s_x)
+        @test array_type(output_s_x) <: MArray
+        @test dimension(output_s_x) == dimension(x)^2
+        f(x) = (xi -> xi^2).(x)
+        @inferred f(s_x)
     end
 
     @testset "Utilities" begin
@@ -583,7 +593,7 @@ end
         # type stability:
         @inferred hcat(qarr1, qarr2)
         @inferred vcat(qarr1, qarr2)
-        @inferred cat(qarr1, qarr2, dims=2)
+        @inferred cat(qarr1, qarr2, dims=Val(2))
 
         # same array type:
         s_qarr1 = QuantityArray(SArray{Tuple{3}}(ustrip(qarr1)), dimension(qarr1))

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -666,6 +666,17 @@ end
         @test ustrip(x .* y) == ustrip(x) .* ustrip(y)
     end
 
+    @testset "Broadcast different arrays" begin
+        f(x, y, z, w) = x * y + z * w
+        g(x, y, z, w) = f.(x, y, z, w)
+
+        x = randn(32)
+        y = QuantityArray(randn(32), u"km/s")
+        z = rand(1:10, 32)
+        w = Quantity{Float32}(u"m/s")
+        @test typeof(g(x, y, z, w)) <: QuantityArray{Float64}
+    end
+
     @testset "Broadcast scalars" begin
         for (x, qx) in ((0.5, 0.5u"s"), ([0.5, 0.2], Quantity([0.5, 0.2], time=1)))
             @test size(qx) == size(x)

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1,7 +1,7 @@
 using DynamicQuantities
 using DynamicQuantities: FixedRational
 using DynamicQuantities: DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
-using DynamicQuantities: array_type
+using DynamicQuantities: array_type, value_type, dim_type
 using Ratios: SimpleRatio
 using SaferIntegers: SafeInt16
 using StaticArrays: SArray, MArray
@@ -572,6 +572,8 @@ end
         s_x = QuantityArray(SArray{Tuple{32}}(ustrip(x)), dimension(x))
         output_s_x = (xi -> xi^2).(s_x)
         @test array_type(output_s_x) <: MArray
+        @test dim_type(output_s_x) <: Dimensions{<:FixedRational}
+        @test value_type(output_s_x) == Float64
         @test dimension(output_s_x) == dimension(x)^2
         fv_square2(x) = (xi -> xi^2).(x)
         @inferred fv_square2(s_x)

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -393,6 +393,14 @@ end
 @testset "Additional tests of FixedRational" begin
     @test convert(Int64, FixedRational{Int64,1000}(2 // 1)) == 2
     @test convert(Int32, FixedRational{Int64,1000}(3 // 1)) == 3
+
+    VERSION >= v"1.8" && @test_throws "Refusing to" promote(FixedRational{Int,10}(2), FixedRational{Int,4}(2))
+
+    f64 = FixedRational{Int,10}(2)
+    f8 = FixedRational{Int8,10}(2)
+    @test promote(f64, f8) == (2, 2)
+    @test typeof(promote(f64, f8)) == typeof((f64, f64))
+    @test typeof(promote(FixedRational{Int8,10}(2), FixedRational{Int8,10}(2))) == typeof((f8, f8))
 end
 
 struct MyDimensions{R} <: AbstractDimensions{R}
@@ -491,7 +499,7 @@ end
     x = convert(R, 10)
     y = convert(R, 5)
     @test promote(x, y) == (x, y)
-    @test_throws AssertionError promote(x, convert(FixedRational{Int32,100}, 10))
+    @test_throws ErrorException promote(x, convert(FixedRational{Int32,100}, 10))
     @test round(Missing, x) === missing
 
     x = 1.0u"m"

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -449,3 +449,29 @@ end
     @test ustrip(us"Constants.h") == ustrip(u"Constants.h")
     @test ustrip(us"Constants.au") != ustrip(u"Constants.au")
 end
+
+@testset "Arrays" begin
+    x = QuantityArray(randn(32), u"km/s")
+    @test ustrip(sum(x)) == sum(ustrip(x))
+
+    y = randn(32)
+    @test ustrip(QuantityArray(y, u"m")) == y
+
+    f(v) = v^2 * 1.5 - v^2
+    @test sum(f.(QuantityArray(y, u"m"))) == sum(f.(y) .* u"m^2")
+
+    y_q = QuantityArray(y, u"m")
+    @test typeof(f.(y_q)) == typeof(y_q)
+    @test ulength(f.(y_q)) == ulength(y_q) * 2
+
+    @testset "Symbolic units" begin
+        z_ar = randn(32)
+        z = QuantityArray(z_ar, us"Constants.h * km/s")
+        z_true = z_ar .* u"Constants.h * km/s"
+        @test all(expand_units.(z) .≈ z_true)
+        io = IOBuffer()
+        Base.showarg(io, z, true)
+        msg = String(take!(io))
+        @test msg == "QuantityArray(::Vector{Float64}, ::Quantity{Float64, SymbolicDimensions{DynamicQuantities.FixedRational{Int32, 25200}}})"
+    end
+end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -538,6 +538,10 @@ end
     y = WeakRef(s)
     @test_throws ErrorException x == y
     @test_throws ErrorException y == x
+
+    qarr1 = QuantityArray(randn(3), u"km/s")
+    qarr2 = qarr1
+    @test convert(typeof(qarr2), qarr2) === qarr1
 end
 
 @testset "Arrays" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1,7 +1,7 @@
 using DynamicQuantities
 using DynamicQuantities: FixedRational
 using DynamicQuantities: DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
-using DynamicQuantities: array_type, value_type, dim_type
+using DynamicQuantities: array_type, value_type, dim_type, quantity_type
 using Ratios: SimpleRatio
 using SaferIntegers: SafeInt16
 using StaticArrays: SArray, MArray
@@ -264,7 +264,7 @@ end
 
     @test zero(x) == Quantity(0, length=1)
     @test typeof(zero(x)) == Quantity{Int64,DEFAULT_DIM_TYPE}
-    
+
     # Invalid calls:
     @test_throws ErrorException zero(Quantity)
     @test_throws ErrorException zero(Dimensions())
@@ -595,6 +595,52 @@ end
         @test fill(u"m/s", 10) == QuantityArray(fill(1.0, 10) .* u"m/s")
         @test ndims(fill(u"m/s", ())) == 0
         @test fill(u"m/s", ())[begin] == u"m/s"
+    end
+
+    @testset "similar" begin
+        qa = QuantityArray(rand(3, 4), u"m")
+
+        new_qa = similar(qa)
+        @test size(new_qa) == size(qa)
+        @test eltype(new_qa) == eltype(qa)
+        @test dim_type(new_qa) == dim_type(qa)
+        @test quantity_type(new_qa) == eltype(new_qa)
+        @test dimension(new_qa) == dimension(qa)
+        @test isa(ustrip(new_qa), Array{Float64,2})
+        @test !isequal(ustrip(qa), ustrip(new_qa))
+
+        new_qa = similar(qa, Float32)
+        @test eltype(new_qa) <: Quantity{Float32}
+        @test dim_type(new_qa) == dim_type(qa)
+        @test dimension(new_qa) == dimension(qa)
+        @test isa(ustrip(new_qa), Array{Float32,2})
+
+        new_qa = similar(qa, axes(ones(6, 8)))
+        @test size(new_qa) == (6, 8)
+        @test eltype(new_qa) <: Quantity{Float64}
+        @test dim_type(new_qa) == dim_type(qa)
+        @test dimension(new_qa) == dimension(qa)
+        @test isa(ustrip(new_qa), Array{Float64,2})
+
+        new_qa = similar(qa, Float32, axes(ones(6, 8)))
+        @test size(new_qa) == (6, 8)
+        @test eltype(new_qa) <: Quantity{Float32}
+
+        new_qa = similar(qa, Float32, (6,))
+        @test size(new_qa) == (6,)
+        @test eltype(new_qa) <: Quantity{Float32}
+
+        new_qa = similar(qa, (6,))
+        @test size(new_qa) == (6,)
+        @test eltype(new_qa) <: Quantity{Float64}
+
+        new_qa = similar(qa, Float32, (6, UInt(3)))
+        @test size(new_qa) == (6, 3)
+        @test eltype(new_qa) <: Quantity{Float32}
+
+        new_qa = similar(qa, (6, UInt(3)))
+        @test size(new_qa) == (6, 3)
+        @test eltype(new_qa) <: Quantity{Float64}
     end
 
     @testset "Promotion" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -585,6 +585,12 @@ end
         @test g(ar1, array_of_quantities, u"1") == [f(ar1[i], array_of_quantities[i], 1) for i in eachindex(ar1)]
     end
 
+    @testset "Broadcast nd-arrays" begin
+        x = QuantityArray(randn(3, 3), u"A")
+        y = QuantityArray(randn(3, 3), u"cd")
+        @test ustrip(x .* y) == ustrip(x) .* ustrip(y)
+    end
+
     @testset "Symbolic units" begin
         z_ar = randn(32)
         z = QuantityArray(z_ar, us"Constants.h * km/s")

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -580,9 +580,9 @@ end
 
         @test typeof(Base.broadcasted(f, ar1, array_of_quantities, 1.0).args[end]) == Float64
         q = u"1"
-        # TODO: Seems to be failing to broadcast Quantity{Float64}:
-        @test_skip typeof(Base.broadcasted(f, ar1, array_of_quantities, q).args[end]) == q
+        @test typeof(Base.broadcasted(f, ar1, array_of_quantities, q).args[end]) == typeof(q)
 
+        # TODO: Type inference here needs to be fixed
         @test_skip @inferred g(ar1, array_of_quantities, u"1")
         @test g(ar1, array_of_quantities, u"1") == [f(ar1[i], array_of_quantities[i], 1) for i in eachindex(ar1)]
     end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -541,9 +541,13 @@ end
         f(v) = v^2 * 1.5 - v^2
         @test sum(f.(QuantityArray(y, u"m"))) == sum(f.(y) .* u"m^2")
 
-        y_q = QuantityArray(y, u"m")
+        y_q = QuantityArray(y, u"m * cd / s")
         @test typeof(f.(y_q)) == typeof(y_q)
-        @test ulength(f.(y_q)) == ulength(y_q) * 2
+
+        for get_u in (ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount)
+            @test get_u(f.(y_q)) == get_u(y_q) * 2
+            @test get_u(f(first(y_q))) == get_u(y_q) * 2
+        end
 
         fv(v) = f.(v)
         @inferred fv(y_q)

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -524,6 +524,9 @@ end
     @test typeof(f.(y_q)) == typeof(y_q)
     @test ulength(f.(y_q)) == ulength(y_q) * 2
 
+    fv(v) = @. f(v)
+    @inferred fv(y_q)
+
     @test fill(u"m/s", 10) == QuantityArray(fill(1.0, 10) .* u"m/s")
 
     @testset "Symbolic units" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -702,7 +702,7 @@ end
         @test msg == "QuantityArray(::Vector{Float64}, ::DynamicQuantities.Quantity{Float64, DynamicQuantities.SymbolicDimensions{DynamicQuantities.FixedRational{Int32, 25200}}})"
 
         io = IOBuffer()
-        Base.show(io, typeof(z))
+        Base.show(io, MIME"text/plain"(), typeof(z))
         msg2 = String(take!(io))
         @test msg2 == msg
     end


### PR DESCRIPTION
This creates a type:
```julia
QuantityArray{
    T,
    N,
    D<:AbstractDimensions,
    Q<:AbstractQuantity{T,D},
    V<:AbstractVector{T,N}
} <: AbstractArray{Q,N}
```
that stores a single set of physical dimensions for the entire array. 

For example:

```julia
A = QuantityArray(randn(32), u"km/s”)
```

it implements a custom broadcasting interface so as to create a new `QuantityArray` with the correct output dimensions. This part is a bit involved as it needs to materialize the first element. Thanks to tictaccat on Discourse for help.

Everything is type stable.

For safety purposes, the compiler is in charge of figuring out when the dimension calculation can be skipped for each element or not. It should be able to if it inlines things correctly, which happens for simple broadcasting. For more complex broadcasting it might not be able to inline things.

@ChrisRackauckas do you think you or someone else in @SciML could review this to see if it fits your requirements?