### PR TITLE
Redefine `float` to match Unitful and return quantity

### DIFF
--- a/ext/DynamicQuantitiesLinearAlgebraExt.jl
+++ b/ext/DynamicQuantitiesLinearAlgebraExt.jl
@@ -4,6 +4,5 @@ import LinearAlgebra: norm
 import DynamicQuantities: AbstractQuantity, ustrip, dimension, new_quantity
 
 norm(q::AbstractQuantity, p::Real=2) = new_quantity(typeof(q), norm(ustrip(q), p), dimension(q))
-norm(q::AbstractArray{<:AbstractQuantity}, p::Real=2) = new_quantity(eltype(q), norm(ustrip(q), p), dimension(q))
 
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -26,7 +26,7 @@ end
     return output
 end
 
-Base.float(q::AbstractQuantity{T}) where {T<:AbstractFloat} = convert(T, q)
+Base.float(q::AbstractQuantity) = new_quantity(typeof(q), float(ustrip(q)), dimension(q))
 Base.convert(::Type{T}, q::AbstractQuantity) where {T<:Real} =
     let
         @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
@@ -192,7 +192,6 @@ Remove the units from a quantity.
 """
 @inline ustrip(q::AbstractQuantity) = q.value
 ustrip(::AbstractDimensions) = error("Cannot remove units from an `AbstractDimensions` object.")
-ustrip(aq::AbstractArray{<:AbstractQuantity}) = ustrip.(aq)
 @inline ustrip(q) = q
 
 """

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -201,12 +201,12 @@ end
     end
 
     x = randn(32) .* u"km/s"
-    @test ustrip(x) == ustrip.(x)
-    @test dimension(x) == dimension(u"km/s")
+    @test ustrip.(x) == [ustrip(xi) for xi in x]
+    @test dimension.(x) == [dimension(u"km/s") for xi in x]
     @test_throws DimensionError dimension([u"km/s", u"km"])
 
     @test norm(x, 2) ≈ norm(ustrip.(x), 2) * u"m/s"
-    @test norm(Quantity(ustrip(x), length=1, time=-1), 2) ≈ norm(ustrip.(x), 2) * u"m/s"
+    @test norm(Quantity(ustrip.(x), length=1, time=-1), 2) ≈ norm(ustrip.(x), 2) * u"m/s"
 
     @test ustrip(x') == ustrip(x)'
 end


### PR DESCRIPTION
cc @gaurav-arya

This also removes the `norm` defined on arrays, as it is no longer needed.