### PR TITLE
Fix broadcast stack overflow

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -66,6 +66,9 @@ function Base.promote_rule(::Type{QA1}, ::Type{QA2}) where {QA1<:QuantityArray,Q
 end
 
 function Base.convert(::Type{QA1}, A::QA2) where {QA1<:QuantityArray,QA2<:QuantityArray}
+    if A isa QA1
+        return A
+    end
     Q = quantity_type(QA1)
     V = array_type(QA1)
     N = ndims(QA1)


### PR DESCRIPTION
Presumably on 1.10 the broadcast/convert logic is smart enough to not call that `convert` method in the first place. Mirrors logic in e.g. https://github.com/JuliaLang/julia/blob/b3741c01f2e2d4956be3ba41858c4065c6fbc7e8/base/array.jl#L663