### PR TITLE
Ensure user-defined mutable version of dimensions always copied

### DIFF
--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -182,6 +182,10 @@ Base.showarg(io::IO, v::QuantityArray, _) = _print_array_type(io, typeof(v))
 Base.show(io::IO, ::MIME"text/plain", ::Type{QA}) where {QA<:QuantityArray} = _print_array_type(io, QA)
 
 # Other array operations:
+Base.resize!(A::QuantityArray, n) = (resize!(ustrip(A), n); A)
+Base.empty!(A::QuantityArray) = (empty!(ustrip(A)); A)
+Base.empty(A::QuantityArray) = QuantityArray(empty(ustrip(A)), copy(dimension(A)), quantity_type(A))
+Base.zero(A::QuantityArray) = QuantityArray(zero(ustrip(A)), copy(dimension(A)), quantity_type(A))
 Base.copy(A::QuantityArray) = QuantityArray(copy(ustrip(A)), copy(dimension(A)), quantity_type(A))
 for f in (:cat, :hcat, :vcat)
     preamble = quote

--- a/src/math.jl
+++ b/src/math.jl
@@ -2,8 +2,8 @@ Base.:*(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(+, l, r)
 Base.:*(l::AbstractQuantity, r::AbstractQuantity) = new_quantity(typeof(l), ustrip(l) * ustrip(r), dimension(l) * dimension(r))
 Base.:*(l::AbstractQuantity, r::AbstractDimensions) = new_quantity(typeof(l), ustrip(l), dimension(l) * r)
 Base.:*(l::AbstractDimensions, r::AbstractQuantity) = new_quantity(typeof(r), ustrip(r), l * dimension(r))
-Base.:*(l::AbstractQuantity, r) = new_quantity(typeof(l), ustrip(l) * r, dimension(l))
-Base.:*(l, r::AbstractQuantity) = new_quantity(typeof(r), l * ustrip(r), dimension(r))
+Base.:*(l::AbstractQuantity, r) = new_quantity(typeof(l), ustrip(l) * r, copy(dimension(l)))
+Base.:*(l, r::AbstractQuantity) = new_quantity(typeof(r), l * ustrip(r), copy(dimension(r)))
 Base.:*(l::AbstractDimensions, r) = error("Please use an `AbstractQuantity` for multiplication. You used multiplication on types: $(typeof(l)) and $(typeof(r)).")
 Base.:*(l, r::AbstractDimensions) = error("Please use an `AbstractQuantity` for multiplication. You used multiplication on types: $(typeof(l)) and $(typeof(r)).")
 
@@ -11,7 +11,7 @@ Base.:/(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(-, l, r)
 Base.:/(l::AbstractQuantity, r::AbstractQuantity) = new_quantity(typeof(l), ustrip(l) / ustrip(r), dimension(l) / dimension(r))
 Base.:/(l::AbstractQuantity, r::AbstractDimensions) = new_quantity(typeof(l), ustrip(l), dimension(l) / r)
 Base.:/(l::AbstractDimensions, r::AbstractQuantity) = new_quantity(typeof(r), inv(ustrip(r)), l / dimension(r))
-Base.:/(l::AbstractQuantity, r) = new_quantity(typeof(l), ustrip(l) / r, dimension(l))
+Base.:/(l::AbstractQuantity, r) = new_quantity(typeof(l), ustrip(l) / r, copy(dimension(l)))
 Base.:/(l, r::AbstractQuantity) = l * inv(r)
 Base.:/(l::AbstractDimensions, r) = error("Please use an `AbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
 Base.:/(l, r::AbstractDimensions) = error("Please use an `AbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
@@ -19,20 +19,20 @@ Base.:/(l, r::AbstractDimensions) = error("Please use an `AbstractQuantity` for 
 Base.:+(l::AbstractQuantity, r::AbstractQuantity) =
     let
         dimension(l) == dimension(r) || throw(DimensionError(l, r))
-        new_quantity(typeof(l), ustrip(l) + ustrip(r), dimension(l))
+        new_quantity(typeof(l), ustrip(l) + ustrip(r), copy(dimension(l)))
     end
-Base.:-(l::AbstractQuantity) = new_quantity(typeof(l), -ustrip(l), dimension(l))
+Base.:-(l::AbstractQuantity) = new_quantity(typeof(l), -ustrip(l), copy(dimension(l)))
 Base.:-(l::AbstractQuantity, r::AbstractQuantity) = l + (-r)
 
 Base.:+(l::AbstractQuantity, r) =
     let
         iszero(dimension(l)) || throw(DimensionError(l, r))
-        new_quantity(typeof(l), ustrip(l) + r, dimension(l))
+        new_quantity(typeof(l), ustrip(l) + r, copy(dimension(l)))
     end
 Base.:+(l, r::AbstractQuantity) =
     let
         iszero(dimension(r)) || throw(DimensionError(l, r))
-        new_quantity(typeof(r), l + ustrip(r), dimension(r))
+        new_quantity(typeof(r), l + ustrip(r), copy(dimension(r)))
     end
 Base.:-(l::AbstractQuantity, r) = l + (-r)
 Base.:-(l, r::AbstractQuantity) = l + (-r)
@@ -77,6 +77,6 @@ Base.sqrt(q::AbstractQuantity) = new_quantity(typeof(q), sqrt(ustrip(q)), sqrt(d
 Base.cbrt(d::AbstractDimensions{R}) where {R} = d^inv(convert(R, 3))
 Base.cbrt(q::AbstractQuantity) = new_quantity(typeof(q), cbrt(ustrip(q)), cbrt(dimension(q)))
 
-Base.abs(q::AbstractQuantity) = new_quantity(typeof(q), abs(ustrip(q)), dimension(q))
+Base.abs(q::AbstractQuantity) = new_quantity(typeof(q), abs(ustrip(q)), copy(dimension(q)))
 Base.abs2(q::AbstractQuantity) = new_quantity(typeof(q), abs2(ustrip(q)), dimension(q)^2)
 Base.angle(q::AbstractQuantity{T}) where {T<:Complex} = angle(ustrip(q))

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -615,6 +615,30 @@ end
         @test x != xc
     end
 
+    @testset "Array resizing" begin
+        qa = QuantityArray([1., 2., 3.], u"m/s")
+
+        @test size(qa) == (3,)
+        @test size(empty(qa)) == (0,)
+        @test typeof(empty(qa)) == typeof(qa)
+
+        push!(qa, 4.0u"m/s")
+
+        @test qa[4] == 4.0u"m/s"
+
+        @test size(zero(qa)) == (4,)
+        @test dimension(zero(qa)) == dimension(qa)
+        @test dimension(empty(qa)) == dimension(qa)
+
+        empty!(qa)
+
+        @test size(qa) == (0,)
+
+        resize!(qa, 3)
+
+        @test size(qa) == (3,)
+    end
+
     @testset "Utilities" begin
         @test fill(u"m/s", 10) == QuantityArray(fill(1.0, 10) .* u"m/s")
         @test ndims(fill(u"m/s", ())) == 0


### PR DESCRIPTION
While the default `Dimensions` is immutable, and the mutable `SymbolicDimensions` (which uses a sparse array) should always create a copy anyways, the user could declare a `AbstractDimensions` that is mutable and does not copy itself.

Therefore this PR implements `copy` for a variety of operations on both `QuantityArray` and `AbstractQuantity`.

todo:
- [ ] turn off copies for broadcasting interface