### PR TITLE
Add `uconvert` and chemistry example

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ julia> expand_units(x^2)
 8.987551787368176e16 m² s⁻⁴
 ```
 
-You can also convert a quantity in regular base SI units to symbolic units with `as_u`:
+You can also convert a quantity in regular base SI units to symbolic units with `uconvert`:
 ```julia
-julia> as_u(5e-9u"m", us"nm") # can also write 5e-9u"m" |> as_u(us"nm")
+julia> uconvert(us"nm", 5e-9u"m") # can also write 5e-9u"m" |> uconvert(us"nm")
 5.0 nm
 ```
 

--- a/README.md
+++ b/README.md
@@ -207,9 +207,9 @@ julia> expand_units(x^2)
 8.987551787368176e16 m² s⁻⁴
 ```
 
-You can also convert a quantity in regular base SI units to symbolic units with `as_units`:
+You can also convert a quantity in regular base SI units to symbolic units with `as_u`:
 ```julia
-julia> as_units(5e-9u"m", us"nm") # can also write 5e-9u"m" |> as_units(us"nm")
+julia> as_u(5e-9u"m", us"nm") # can also write 5e-9u"m" |> as_u(us"nm")
 5.0 nm
 ```
 

--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ julia> expand_units(x^2)
 
 You can also convert a quantity in regular base SI units to symbolic units with `as_units`:
 ```julia
-julia> as_units(5e-9u"m", us"nm")
+julia> as_units(5e-9u"m", us"nm") # can also write 5e-9u"m" |> as_units(us"nm")
 5.0 nm
 ```
 

--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ julia> expand_units(x^2)
 8.987551787368176e16 m² s⁻⁴
 ```
 
+You can also convert a quantity in regular base SI units to symbolic units with `as_units`:
+```julia
+julia> as_units(5e-9u"m", us"nm")
+5.0 nm
+```
+
 ### Arrays
 
 For working with an array of quantities that have the same dimensions,

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,2 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+DynamicQuantities = "06fc5a27-2a28-4c7c-a15d-362465fb6821"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -39,6 +39,7 @@ makedocs(;
     ),
     pages=[
         "Home" => "index.md",
+        "Examples" => "examples.md",
         "Utilities" => "api.md",
         "Units" => "units.md",
         "Constants" => "constants.md",

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,0 +1,25 @@
+# Toy Examples with Code
+
+```julia
+using DynamicQuantities
+```
+
+## 1. Solving a Chemistry Homework Problem
+
+On your chemistry homework, you are faced with the following problem:
+
+> In a photoelectric effect experiment, electrons are ejected from a titanium surface (work function ``\Phi = 4.33\mathrm{eV}``) following irradition with UV light.
+> The energy of the incident UV light is ``7.2 \cdot 10^{-19} \mathrm{J}`` per photon. Calculate the wavelength of the ejected electrons.
+
+Let's solve this problem with `DynamicQuantities.jl`!
+```@repl
+using DynamicQuantities
+using DynamicQuantities.Constants: h, c, m_e
+Φ = 4.33u"Constants.eV" # work function
+E = 7.2e-19u"J" # incident energy
+p = sqrt(2 * m_e * (E - Φ)) # momentum of ejected electrons
+λ = h / p # wavelength of ejected electrons
+```
+Since units are automatically propagated, we can verify the dimension of our answer and all intermediates.
+Also, using `DynamicQuantities.Constants`, we were able to obtain the (dimensionful!) values of all necessary constants without typing them ourselves.
+

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -30,7 +30,7 @@ julia> p = sqrt(2 * m_e * (E - Φ)) # momentum of ejected electrons
 julia> λ = h / p # wavelength of ejected electrons
 3.029491247878056e-9 m
 
-julia> as_units(λ, us"nm") # return answer in nanometers
+julia> as_u(λ, us"nm") # return answer in nanometers
 3.0294912478780556 nm
 ```
 Since units are automatically propagated, we can verify the dimension of our answer and all intermediates.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -11,7 +11,7 @@ On your chemistry homework, you are faced with the following problem on the phot
 [^1]: Attribution: [MIT OCW](https://ocw.mit.edu/courses/5-111sc-principles-of-chemical-science-fall-2014/resources/mit5_111f14_lec04soln/)
 
 > In a photoelectric effect experiment, electrons are ejected from a titanium surface (work function ``\Phi = 4.33\mathrm{eV}``) following irradition with UV light.
-> The energy of the incident UV light is ``7.2 \cdot 10^{-19} \mathrm{J}`` per photon. Calculate the wavelength of the ejected electrons.
+> The energy of the incident UV light is ``7.2 \cdot 10^{-19} \mathrm{J}`` per photon. Calculate the wavelength of the ejected electrons, in nanometers.
 
 Let's solve this problem with `DynamicQuantities.jl`!
 ```@repl
@@ -21,6 +21,7 @@ using DynamicQuantities.Constants: h, c, m_e
 E = 7.2e-19u"J" # incident energy
 p = sqrt(2 * m_e * (E - Φ)) # momentum of ejected electrons
 λ = h / p # wavelength of ejected electrons
+as_units(λ, us"nm") # return answer in nanometers
 ```
 Since units are automatically propagated, we can verify the dimension of our answer and all intermediates.
 Also, using `DynamicQuantities.Constants`, we were able to obtain the (dimensionful!) values of all necessary constants without typing them ourselves.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -30,7 +30,7 @@ julia> p = sqrt(2 * m_e * (E - Φ)) # momentum of ejected electrons
 julia> λ = h / p # wavelength of ejected electrons
 3.029491247878056e-9 m
 
-julia> as_u(λ, us"nm") # return answer in nanometers
+julia> uconvert(us"nm", λ) # return answer in nanometers
 3.0294912478780556 nm
 ```
 Since units are automatically propagated, we can verify the dimension of our answer and all intermediates.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -6,7 +6,9 @@ using DynamicQuantities
 
 ## 1. Solving a Chemistry Homework Problem
 
-On your chemistry homework, you are faced with the following problem:
+On your chemistry homework, you are faced with the following problem on the photoelectric effect[^1]:
+
+[^1]: Attribution: [MIT OCW](https://ocw.mit.edu/courses/5-111sc-principles-of-chemical-science-fall-2014/resources/mit5_111f14_lec04soln/)
 
 > In a photoelectric effect experiment, electrons are ejected from a titanium surface (work function ``\Phi = 4.33\mathrm{eV}``) following irradition with UV light.
 > The energy of the incident UV light is ``7.2 \cdot 10^{-19} \mathrm{J}`` per photon. Calculate the wavelength of the ejected electrons.

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,10 +1,5 @@
 # Toy Examples with Code
 
-```jldoctest examples
-julia> using DynamicQuantities
-
-```
-
 ## 1. Solving a Chemistry Homework Problem
 
 On your chemistry homework, you are faced with the following problem on the photoelectric effect[^1]:
@@ -16,6 +11,8 @@ On your chemistry homework, you are faced with the following problem on the phot
 
 Let's solve this problem with `DynamicQuantities.jl`!
 ```jldoctest examples
+julia> using DynamicQuantities
+
 julia> using DynamicQuantities.Constants: h, m_e
 
 julia> Φ = 4.33u"Constants.eV" # work function

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -1,7 +1,8 @@
 # Toy Examples with Code
 
-```julia
-using DynamicQuantities
+```jldoctest examples
+julia> using DynamicQuantities
+
 ```
 
 ## 1. Solving a Chemistry Homework Problem
@@ -14,14 +15,23 @@ On your chemistry homework, you are faced with the following problem on the phot
 > The energy of the incident UV light is ``7.2 \cdot 10^{-19} \mathrm{J}`` per photon. Calculate the wavelength of the ejected electrons, in nanometers.
 
 Let's solve this problem with `DynamicQuantities.jl`!
-```@repl
-using DynamicQuantities
-using DynamicQuantities.Constants: h, c, m_e
-Φ = 4.33u"Constants.eV" # work function
-E = 7.2e-19u"J" # incident energy
-p = sqrt(2 * m_e * (E - Φ)) # momentum of ejected electrons
-λ = h / p # wavelength of ejected electrons
-as_units(λ, us"nm") # return answer in nanometers
+```jldoctest examples
+julia> using DynamicQuantities.Constants: h, m_e
+
+julia> Φ = 4.33u"Constants.eV" # work function
+6.93742482522e-19 m² kg s⁻²
+
+julia> E = 7.2e-19u"J" # incident energy
+7.2e-19 m² kg s⁻²
+
+julia> p = sqrt(2 * m_e * (E - Φ)) # momentum of ejected electrons
+2.1871890716439906e-25 m kg s⁻¹
+
+julia> λ = h / p # wavelength of ejected electrons
+3.029491247878056e-9 m
+
+julia> as_units(λ, us"nm") # return answer in nanometers
+3.0294912478780556 nm
 ```
 Since units are automatically propagated, we can verify the dimension of our answer and all intermediates.
 Also, using `DynamicQuantities.Constants`, we were able to obtain the (dimensionful!) values of all necessary constants without typing them ourselves.

--- a/docs/src/symbolic_units.md
+++ b/docs/src/symbolic_units.md
@@ -20,8 +20,8 @@ To convert a quantity to its regular base SI units, use `expand_units`:
 expand_units
 ```
 
-To convert a quantity in regular base SI units to corresponding symbolic units, use `as_units`:
+To convert a quantity in regular base SI units to corresponding symbolic units, use `as_u`:
 
 ```@docs
-as_units
+as_u
 ```

--- a/docs/src/symbolic_units.md
+++ b/docs/src/symbolic_units.md
@@ -20,8 +20,8 @@ To convert a quantity to its regular base SI units, use `expand_units`:
 expand_units
 ```
 
-To convert a quantity in regular base SI units to corresponding symbolic units, use `as_u`:
+To convert a quantity in regular base SI units to corresponding symbolic units, use `uconvert`:
 
 ```@docs
-as_u
+uconvert
 ```

--- a/docs/src/symbolic_units.md
+++ b/docs/src/symbolic_units.md
@@ -19,3 +19,9 @@ To convert a quantity to its regular base SI units, use `expand_units`:
 ```@docs
 expand_units
 ```
+
+To convert a quantity in regular base SI units to corresponding symbolic units, use `as_units`:
+
+```@docs
+as_units
+```

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -15,7 +15,7 @@ export AbstractQuantity, AbstractDimensions
 export Quantity, Dimensions, SymbolicDimensions, QuantityArray, DimensionError
 export ustrip, dimension
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
-export uparse, @u_str, sym_uparse, @us_str, expand_units, as_units
+export uparse, @u_str, sym_uparse, @us_str, expand_units, as_u
 
 include("fixed_rational.jl")
 include("types.jl")

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -5,7 +5,7 @@ export AbstractQuantity, AbstractDimensions
 export Quantity, Dimensions, SymbolicDimensions, QuantityArray, DimensionError
 export ustrip, dimension
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
-export uparse, @u_str, sym_uparse, @us_str, expand_units, as_u
+export uparse, @u_str, sym_uparse, @us_str, expand_units, uconvert
 
 include("fixed_rational.jl")
 include("types.jl")

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -15,7 +15,7 @@ export AbstractQuantity, AbstractDimensions
 export Quantity, Dimensions, SymbolicDimensions, QuantityArray, DimensionError
 export ustrip, dimension
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
-export uparse, @u_str, sym_uparse, @us_str, expand_units
+export uparse, @u_str, sym_uparse, @us_str, expand_units, as_units
 
 include("fixed_rational.jl")
 include("types.jl")

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -114,7 +114,7 @@ Convert a quantity `q` with base SI units to the symbolic units of `qout`, for `
 Mathematically, the result has value `q / expand_units(qout)` and units `dimension(qout)`. 
 """
 function uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}, q::AbstractQuantity{<:Any, <:Dimensions})
-    isone(ustrip(qout)) || error("You passed a quantity with a non-unit value to uconvert.")
+    @assert isone(ustrip(qout)) "You passed a quantity with a non-unit value to uconvert."
     qout_expanded = expand_units(qout)
     dimension(q) == dimension(qout_expanded) || throw(DimensionError(q, qout_expanded))
     new_val = ustrip(q) / ustrip(qout_expanded)

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -114,6 +114,14 @@ a function equivalent to `q -> as_u(q, qout)`.
 """
 as_u(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}) = Base.Fix2(as_u, qout)
 
+"""
+    as_u(q::AbstractQuantity{<:Any, <:Dimensions}, qout::String)
+
+Convert a quantity `q` with base SI units to a set of compatible units specified of `qout`.
+Internally, this works by parsing `qout` as a symbolic unit, so this is equivalent to `as_u(q, sym_uparse(qout))`. 
+"""
+as_u(q::AbstractQuantity{<:Any, <:Dimensions}, qout::String) = as_u(q, sym_uparse(qout))
+
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(data(d)))
 Base.:(==)(l::SymbolicDimensions, r::SymbolicDimensions) = data(l) == data(r)
 Base.iszero(d::SymbolicDimensions) = iszero(data(d))

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -94,6 +94,17 @@ function expand_units(q::Q) where {T,R,D<:SymbolicDimensions{R},Q<:AbstractQuant
 end
 expand_units(q::QuantityArray) = expand_units.(q)
 
+"""
+    as_units(q::AbstractQuantity{<:Any, <:Dimensions}, qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
+
+Convert a quantity `q` with base SI units to the symbolic units of `qout`, for `q` and `qout` with compatible units.
+Mathematically, the result has value `q / expand_units(qout)` and units `dimension(qout)`. 
+"""
+function as_units(q::AbstractQuantity{<:Any, <:Dimensions}, qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
+    qout_expanded = expand_units(qout)
+    dimension(q) == dimension(qout_expanded) || throw(DimensionError(q, qout_expanded))
+    return new_quantity(typeof(qout), ustrip(q) / ustrip(qout_expanded), dimension(qout))
+end
 
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(data(d)))
 Base.:(==)(l::SymbolicDimensions, r::SymbolicDimensions) = data(l) == data(r)

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -113,11 +113,13 @@ expand_units(q::QuantityArray) = expand_units.(q)
 Convert a quantity `q` with base SI units to the symbolic units of `qout`, for `q` and `qout` with compatible units.
 Mathematically, the result has value `q / expand_units(qout)` and units `dimension(qout)`. 
 """
-function uconvert(qout::AbstractQuantity{T, <:SymbolicDimensions}, q::AbstractQuantity{<:Any, <:Dimensions}) where {T}
+function uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}, q::AbstractQuantity{<:Any, <:Dimensions})
     isone(ustrip(qout)) || error("You passed a quantity with a non-unit value to uconvert.")
     qout_expanded = expand_units(qout)
     dimension(q) == dimension(qout_expanded) || throw(DimensionError(q, qout_expanded))
-    return new_quantity(typeof(qout), ustrip(q) / ustrip(qout_expanded), dimension(qout))
+    new_val = ustrip(q) / ustrip(qout_expanded)
+    new_dim = dimension(qout)
+    return new_quantity(typeof(q), new_val, new_dim)
 end
 
 """

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -96,31 +96,29 @@ expand_units(q::QuantityArray) = expand_units.(q)
 
 """
     as_u(q::AbstractQuantity{<:Any, <:Dimensions}, qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
+    as_u(q::AbstractQuantity{<:Any, <:Dimensions}, ustr::String)
 
 Convert a quantity `q` with base SI units to the symbolic units of `qout`, for `q` and `qout` with compatible units.
 Mathematically, the result has value `q / expand_units(qout)` and units `dimension(qout)`. 
+For string input, `qout` is created by parsing `ustr` as a symbolic unit, i.e. `qout = sym_uparse(ustr)`.
 """
 function as_u(q::AbstractQuantity{<:Any, <:Dimensions}, qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
     qout_expanded = expand_units(qout)
     dimension(q) == dimension(qout_expanded) || throw(DimensionError(q, qout_expanded))
     return new_quantity(typeof(qout), ustrip(q) / ustrip(qout_expanded), dimension(qout))
 end
+as_u(q::AbstractQuantity{<:Any, <:Dimensions}, ustr::String) = as_u(q, sym_uparse(ustr)) 
 
 """
     as_u(qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
+    as_u(ustr::String)
 
 Create a function that converts an input quantity `q` with base SI units to the symbolic units of `qout`, i.e 
 a function equivalent to `q -> as_u(q, qout)`.
+For string input, `qout` is created by parsing `ustr` as a symbolic unit, i.e. `qout = sym_uparse(ustr)`.
 """
 as_u(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}) = Base.Fix2(as_u, qout)
-
-"""
-    as_u(q::AbstractQuantity{<:Any, <:Dimensions}, qout::String)
-
-Convert a quantity `q` with base SI units to a set of compatible units specified of `qout`.
-Internally, this works by parsing `qout` as a symbolic unit, so this is equivalent to `as_u(q, sym_uparse(qout))`. 
-"""
-as_u(q::AbstractQuantity{<:Any, <:Dimensions}, qout::String) = as_u(q, sym_uparse(qout))
+as_u(ustr::String) = Base.Fix2(as_u, ustr)
 
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(data(d)))
 Base.:(==)(l::SymbolicDimensions, r::SymbolicDimensions) = data(l) == data(r)

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -113,7 +113,8 @@ expand_units(q::QuantityArray) = expand_units.(q)
 Convert a quantity `q` with base SI units to the symbolic units of `qout`, for `q` and `qout` with compatible units.
 Mathematically, the result has value `q / expand_units(qout)` and units `dimension(qout)`. 
 """
-function uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}, q::AbstractQuantity{<:Any, <:Dimensions})
+function uconvert(qout::AbstractQuantity{T, <:SymbolicDimensions}, q::AbstractQuantity{<:Any, <:Dimensions}) where {T}
+    isone(ustrip(qout)) || error("You passed a quantity with a non-unit value to uconvert.")
     qout_expanded = expand_units(qout)
     dimension(q) == dimension(qout_expanded) || throw(DimensionError(q, qout_expanded))
     return new_quantity(typeof(qout), ustrip(q) / ustrip(qout_expanded), dimension(qout))

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -109,29 +109,23 @@ expand_units(q::QuantityArray) = expand_units.(q)
 
 """
     uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}, q::AbstractQuantity{<:Any, <:Dimensions})
-    uconvert(ustr::String, q::AbstractQuantity{<:Any, <:Dimensions})
 
 Convert a quantity `q` with base SI units to the symbolic units of `qout`, for `q` and `qout` with compatible units.
 Mathematically, the result has value `q / expand_units(qout)` and units `dimension(qout)`. 
-For string input, `qout` is created by parsing `ustr` as a symbolic unit, i.e. `qout = sym_uparse(ustr)`.
 """
 function uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}, q::AbstractQuantity{<:Any, <:Dimensions})
     qout_expanded = expand_units(qout)
     dimension(q) == dimension(qout_expanded) || throw(DimensionError(q, qout_expanded))
     return new_quantity(typeof(qout), ustrip(q) / ustrip(qout_expanded), dimension(qout))
 end
-uconvert(ustr::String, q::AbstractQuantity{<:Any, <:Dimensions}) = uconvert(sym_uparse(ustr), q) 
 
 """
     uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
-    uconvert(ustr::String)
 
 Create a function that converts an input quantity `q` with base SI units to the symbolic units of `qout`, i.e 
 a function equivalent to `q -> uconvert(qout, q)`.
-For string input, `qout` is created by parsing `ustr` as a symbolic unit, i.e. `qout = sym_uparse(ustr)`.
 """
 uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}) = Base.Fix1(uconvert, qout)
-uconvert(ustr::String) = uconvert(sym_uparse(ustr))
 
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(getfield(d, :nzdims)), copy(getfield(d, :nzvals)))
 function Base.:(==)(l::SymbolicDimensions, r::SymbolicDimensions)

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -106,6 +106,14 @@ function as_units(q::AbstractQuantity{<:Any, <:Dimensions}, qout::AbstractQuanti
     return new_quantity(typeof(qout), ustrip(q) / ustrip(qout_expanded), dimension(qout))
 end
 
+"""
+    as_units(qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
+
+Create a function that converts an input quantity `q` with base SI units to the symbolic units of `qout`, i.e 
+a function equivalent to `q -> as_units(q, qout)`.
+"""
+as_units(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}) = Base.Fix2(as_units, qout)
+
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(data(d)))
 Base.:(==)(l::SymbolicDimensions, r::SymbolicDimensions) = data(l) == data(r)
 Base.iszero(d::SymbolicDimensions) = iszero(data(d))

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -95,24 +95,24 @@ end
 expand_units(q::QuantityArray) = expand_units.(q)
 
 """
-    as_units(q::AbstractQuantity{<:Any, <:Dimensions}, qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
+    as_u(q::AbstractQuantity{<:Any, <:Dimensions}, qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
 
 Convert a quantity `q` with base SI units to the symbolic units of `qout`, for `q` and `qout` with compatible units.
 Mathematically, the result has value `q / expand_units(qout)` and units `dimension(qout)`. 
 """
-function as_units(q::AbstractQuantity{<:Any, <:Dimensions}, qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
+function as_u(q::AbstractQuantity{<:Any, <:Dimensions}, qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
     qout_expanded = expand_units(qout)
     dimension(q) == dimension(qout_expanded) || throw(DimensionError(q, qout_expanded))
     return new_quantity(typeof(qout), ustrip(q) / ustrip(qout_expanded), dimension(qout))
 end
 
 """
-    as_units(qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
+    as_u(qout::AbstractQuantity{<:Any, <:SymbolicDimensions})
 
 Create a function that converts an input quantity `q` with base SI units to the symbolic units of `qout`, i.e 
-a function equivalent to `q -> as_units(q, qout)`.
+a function equivalent to `q -> as_u(q, qout)`.
 """
-as_units(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}) = Base.Fix2(as_units, qout)
+as_u(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}) = Base.Fix2(as_u, qout)
 
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(data(d)))
 Base.:(==)(l::SymbolicDimensions, r::SymbolicDimensions) = data(l) == data(r)

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -526,6 +526,9 @@ end
     @test us"Constants.h" != us"h"
     @test expand_units(us"Constants.h") == u"Constants.h"
 
+    @test as_units(5e-9u"m", us"nm") ≈ 5us"nm"
+    @test_throws DimensionError as_units(5e-9u"m", us"nm * J")
+
     # Actually expands to:
     @test dimension(us"Constants.h")[:m] == 2
     @test dimension(us"Constants.h")[:s] == -1

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -604,7 +604,7 @@ end
     @test expand_units(qs) ≈ 5.0 * q
 
     # Refuses to convert to non-unit quantities:
-    @test_throws ErrorException uconvert(1.2us"m", 1.0u"m")
+    @test_throws AssertionError uconvert(1.2us"m", 1.0u"m")
     VERSION >= v"1.8" &&
         @test_throws "You passed a quantity" uconvert(1.2us"m", 1.0u"m")
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -526,8 +526,8 @@ end
     @test us"Constants.h" != us"h"
     @test expand_units(us"Constants.h") == u"Constants.h"
 
-    @test as_units(5e-9u"m", us"nm") ≈ (5e-9u"m" |> as_units(us"nm")) ≈ 5us"nm"
-    @test_throws DimensionError as_units(5e-9u"m", us"nm * J")
+    @test as_u(5e-9u"m", us"nm") ≈ (5e-9u"m" |> as_u(us"nm")) ≈ 5us"nm"
+    @test_throws DimensionError as_u(5e-9u"m", us"nm * J")
 
     # Actually expands to:
     @test dimension(us"Constants.h")[:m] == 2

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -605,6 +605,14 @@ end
 
     # Refuses to convert to non-unit quantities:
     @test_throws ErrorException uconvert(1.2us"m", 1.0u"m")
+    VERSION >= v"1.8" &&
+        @test_throws "You passed a quantity" uconvert(1.2us"m", 1.0u"m")
+
+    # Different types require converting both arguments:
+    q = convert(Quantity{Float16}, 1.5u"g")
+    qs = uconvert(convert(Quantity{Float16}, us"g"), 5 * q)
+    @test typeof(qs) <: Quantity{Float16,<:SymbolicDimensions{<:Any}}
+    @test qs ≈ 7.5us"g"
 end
 
 @testset "Test ambiguities" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -526,7 +526,7 @@ end
     @test us"Constants.h" != us"h"
     @test expand_units(us"Constants.h") == u"Constants.h"
 
-    @test as_u(5e-9u"m", us"nm") ≈ (5e-9u"m" |> as_u(us"nm")) ≈ 5us"nm"
+    @test as_u(5e-9u"m", us"nm") ≈ as_u(5e-9u"m", "nm") ≈ (5e-9u"m" |> as_u(us"nm")) ≈ (5e-9u"m" |> as_u("nm")) ≈ 5us"nm"
     @test_throws DimensionError as_u(5e-9u"m", us"nm * J")
 
     # Actually expands to:

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -569,9 +569,6 @@ end
     @test us"Constants.h" != us"h"
     @test expand_units(us"Constants.h") == u"Constants.h"
 
-    @test uconvert(us"nm", 5e-9u"m") ≈ (5e-9u"m" |> uconvert(us"nm")) ≈ 5us"nm"
-    @test_throws DimensionError uconvert(us"nm * J", 5e-9u"m")
-
     # Actually expands to:
     @test dimension(us"Constants.h")[:m] == 2
     @test dimension(us"Constants.h")[:s] == -1
@@ -592,6 +589,22 @@ end
     sym5 = dimension(us"km/s")
     VERSION >= v"1.8" &&
         @test_throws "rad is not available as a symbol" sym5.rad
+end
+
+@testset "uconvert" begin
+    @test uconvert(us"nm", 5e-9u"m") ≈ (5e-9u"m" |> uconvert(us"nm")) ≈ 5us"nm"
+    @test_throws DimensionError uconvert(us"nm * J", 5e-9u"m")
+
+    q = 1.5u"Constants.M_sun"
+    qs = uconvert(us"Constants.M_sun", 5.0 * q)
+    @test qs ≈ 7.5us"Constants.M_sun"
+    @test dimension(qs)[:kg] == 0
+    @test dimension(qs)[:g] == 0
+    @test dimension(qs)[:M_sun] == 1
+    @test expand_units(qs) ≈ 5.0 * q
+
+    # Refuses to convert to non-unit quantities:
+    @test_throws ErrorException uconvert(1.2us"m", 1.0u"m")
 end
 
 @testset "Test ambiguities" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -569,7 +569,7 @@ end
     @test us"Constants.h" != us"h"
     @test expand_units(us"Constants.h") == u"Constants.h"
 
-    @test uconvert(us"nm", 5e-9u"m") ≈ uconvert("nm", 5e-9u"m") ≈ (5e-9u"m" |> uconvert(us"nm")) ≈ (5e-9u"m" |> uconvert("nm")) ≈ 5us"nm"
+    @test uconvert(us"nm", 5e-9u"m") ≈ (5e-9u"m" |> uconvert(us"nm")) ≈ 5us"nm"
     @test_throws DimensionError uconvert(us"nm * J", 5e-9u"m")
 
     # Actually expands to:

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -569,8 +569,8 @@ end
     @test us"Constants.h" != us"h"
     @test expand_units(us"Constants.h") == u"Constants.h"
 
-    @test as_u(5e-9u"m", us"nm") ≈ as_u(5e-9u"m", "nm") ≈ (5e-9u"m" |> as_u(us"nm")) ≈ (5e-9u"m" |> as_u("nm")) ≈ 5us"nm"
-    @test_throws DimensionError as_u(5e-9u"m", us"nm * J")
+    @test uconvert(us"nm", 5e-9u"m") ≈ uconvert("nm", 5e-9u"m") ≈ (5e-9u"m" |> uconvert(us"nm")) ≈ (5e-9u"m" |> uconvert("nm")) ≈ 5us"nm"
+    @test_throws DimensionError uconvert(us"nm * J", 5e-9u"m")
 
     # Actually expands to:
     @test dimension(us"Constants.h")[:m] == 2

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -526,7 +526,7 @@ end
     @test us"Constants.h" != us"h"
     @test expand_units(us"Constants.h") == u"Constants.h"
 
-    @test as_units(5e-9u"m", us"nm") ≈ 5us"nm"
+    @test as_units(5e-9u"m", us"nm") ≈ (5e-9u"m" |> as_units(us"nm")) ≈ 5us"nm"
     @test_throws DimensionError as_units(5e-9u"m", us"nm * J")
 
     # Actually expands to:


### PR DESCRIPTION
I was doing my chemistry homework using `DynamicQuantities.jl`, and thought it might make for a nice docs example! This is on top of #47, making the diff a bit noisier.

**Edit:** This PR now also implements `uconvert`, see https://github.com/SymbolicML/DynamicQuantities.jl/pull/48#discussion_r1335061100.