### PR TITLE
Make package a bit more lightweight and improve loading time

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,30 +5,27 @@ version = "0.7.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
-PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [weakdeps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
-ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
 DynamicQuantitiesLinearAlgebraExt = "LinearAlgebra"
 DynamicQuantitiesMeasurementsExt = "Measurements"
-DynamicQuantitiesScientificTypesExt = ["ScientificTypes", "ScientificTypesBase"]
+DynamicQuantitiesScientificTypesExt = "ScientificTypes"
 DynamicQuantitiesUnitfulExt = "Unitful"
 
 [compat]
-Compat = "^3.42, 4"
+Compat = "3.42, 4"
 Measurements = "2"
-PackageExtensionCompat = "1"
+Requires = "1"
 ScientificTypes = "3"
-ScientificTypesBase = "3"
 Tricks = "0.1"
 Unitful = "1"
 julia = "1.6"
@@ -41,22 +38,9 @@ Ratios = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SaferIntegers = "88634af6-177f-5301-88b8-7819386cfa38"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
-ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = [
-    "Aqua",
-    "LinearAlgebra",
-    "Measurements",
-    "Ratios",
-    "SaferIntegers",
-    "SafeTestsets",
-    "ScientificTypes",
-    "ScientificTypesBase",
-    "StaticArrays",
-    "Test",
-    "Unitful"
-]
+test = ["Aqua", "LinearAlgebra", "Measurements", "Ratios", "SaferIntegers", "SafeTestsets", "ScientificTypes", "StaticArrays", "Test", "Unitful"]

--- a/ext/DynamicQuantitiesLinearAlgebraExt.jl
+++ b/ext/DynamicQuantitiesLinearAlgebraExt.jl
@@ -1,7 +1,12 @@
 module DynamicQuantitiesLinearAlgebraExt
 
-import LinearAlgebra: norm
-import DynamicQuantities: AbstractQuantity, ustrip, dimension, new_quantity
+if isdefined(Base, :get_extension)
+    import LinearAlgebra: norm
+    import DynamicQuantities: AbstractQuantity, ustrip, dimension, new_quantity
+else
+    import ..LinearAlgebra: norm
+    import ..DynamicQuantities: AbstractQuantity, ustrip, dimension, new_quantity
+end
 
 norm(q::AbstractQuantity, p::Real=2) = new_quantity(typeof(q), norm(ustrip(q), p), dimension(q))
 

--- a/ext/DynamicQuantitiesMeasurementsExt.jl
+++ b/ext/DynamicQuantitiesMeasurementsExt.jl
@@ -1,7 +1,12 @@
 module DynamicQuantitiesMeasurementsExt
 
-using DynamicQuantities: AbstractQuantity, new_quantity, dimension, ustrip, DimensionError
-using Measurements: Measurements, measurement, value, uncertainty
+if isdefined(Base, :get_extension)
+    using DynamicQuantities: AbstractQuantity, new_quantity, dimension, ustrip, DimensionError
+    using Measurements: Measurements, measurement, value, uncertainty
+else
+    using ..DynamicQuantities: AbstractQuantity, new_quantity, dimension, ustrip, DimensionError
+    using ..Measurements: Measurements, measurement, value, uncertainty
+end
 
 function Measurements.measurement(a::Q, b::Q) where {Q<:AbstractQuantity}
     dimension(a) == dimension(b) || throw(DimensionError(a, b))

--- a/ext/DynamicQuantitiesScientificTypesExt.jl
+++ b/ext/DynamicQuantitiesScientificTypesExt.jl
@@ -1,8 +1,14 @@
 module DynamicQuantitiesScientificTypesExt
 
-import DynamicQuantities: AbstractQuantity, ustrip
-import ScientificTypes as ST
-import ScientificTypesBase as STB
+if isdefined(Base, :get_extension)
+    import DynamicQuantities: AbstractQuantity, ustrip
+    import ScientificTypes as ST
+    import ScientificTypes.ScientificTypesBase as STB
+else
+    import ..DynamicQuantities: AbstractQuantity, ustrip
+    import ..ScientificTypes as ST
+    import ..ScientificTypes.ScientificTypesBase as STB
+end
 
 STB.scitype(x::AbstractQuantity, C::ST.DefaultConvention) = STB.scitype(ustrip(x), C)
 STB.Scitype(::Type{<:AbstractQuantity{T}}, C::ST.DefaultConvention) where {T} = STB.Scitype(T, C)

--- a/ext/DynamicQuantitiesUnitfulExt.jl
+++ b/ext/DynamicQuantitiesUnitfulExt.jl
@@ -1,8 +1,14 @@
 module DynamicQuantitiesUnitfulExt
 
-import DynamicQuantities
-import Unitful
-import Unitful: @u_str
+if isdefined(Base, :get_extension)
+    import DynamicQuantities
+    import Unitful
+    import Unitful: @u_str
+else
+    import ..DynamicQuantities
+    import ..Unitful
+    import ..Unitful: @u_str
+end
 
 function get_si_units()
     return (length=u"m", mass=u"kg", time=u"s", current=u"A", temperature=u"K", luminosity=u"cd", amount=u"mol")

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -1,15 +1,5 @@
 module DynamicQuantities
 
-import TOML: parsefile
-
-const PACKAGE_VERSION = try
-    let project = parsefile(joinpath(pkgdir(@__MODULE__), "Project.toml"))
-        VersionNumber(project["version"])
-    end
-catch
-    VersionNumber(0, 0, 0)
-end
-
 export Units, Constants
 export AbstractQuantity, AbstractDimensions
 export Quantity, Dimensions, SymbolicDimensions, QuantityArray, DimensionError
@@ -27,13 +17,20 @@ include("constants.jl")
 include("uparse.jl")
 include("symbolic_dimensions.jl")
 
-import PackageExtensionCompat: @require_extensions
 import .Units
 import .Constants
 import .UnitsParse: uparse, @u_str
 
+if !isdefined(Base, :get_extension)
+using Requires
+end
+@static if !isdefined(Base, :get_extension)
 function __init__()
-    @require_extensions
+    @require LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e" include("../ext/DynamicQuantitiesLinearAlgebraExt.jl")
+    @require Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7" include("../ext/DynamicQuantitiesMeasurementsExt.jl")
+    @require ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81" include("../ext/DynamicQuantitiesScientificTypesExt.jl")
+    @require Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d" include("../ext/DynamicQuantitiesUnitfulExt.jl")
+end
 end
 
 end

--- a/test/test_scitypes.jl
+++ b/test/test_scitypes.jl
@@ -1,7 +1,6 @@
 using DynamicQuantities
 using ScientificTypes
 import ScientificTypes as ST
-import ScientificTypesBase as STB
 
 x = 1.0u"m/s"
 
@@ -9,7 +8,7 @@ x = 1.0u"m/s"
 @test scitype([x]) <: AbstractVector{<:Continuous}
 @test scitype(Quantity{Int}(x)) <: Count
 @test scitype(randn(32) .* u"m/s") <: AbstractVector{<:Continuous}
-@test STB.Scitype(typeof(x), ST.DefaultConvention()) <: Continuous
+@test ST.ScientificTypesBase.Scitype(typeof(x), ST.DefaultConvention()) <: Continuous
 
 X = (; x=randn(32) .* u"m/s")
 


### PR DESCRIPTION
In the spirit of #53, this makes the package a bit more lightweight and faster to load, in particular on Julia < 1.9:

- Implement package extensions as described in the Pkg docs without PkgExtensionsCompat.jl. This removes an additional layer of complexity and possible source of bugs (it seems most/all issues with the package are fixed but as former issues regarding unsupported use cases and bugs show this concern is real) and significant overhead in older Julia versions where the code in PkgExtensionsCompat.jl is executed. For instance, on Julia 1.6.5 I get on the master branch
  ```julia
  julia> ] precompile

  julia> @time using DynamicQuantities
    0.359792 seconds (1.32 M allocations: 83.207 MiB, 2.38% gc time, 71.25% compilation time)
  ```
  and with this PR
  ```julia
  julia> ] precompile

  julia> @time using DynamicQuantities
    0.140393 seconds (461.62 k allocations: 29.999 MiB, 28.96% compilation time)
  ```
  On Julia 1.9, the effect is less noticeable (since the package is basically empty), on the master branch one gets
  ```julia
  julia> @time_imports using DynamicQuantities
      0.5 ms  Tricks
      0.3 ms  Compat
      0.4 ms  Compat → CompatLinearAlgebraExt
      0.4 ms  PackageExtensionCompat
     44.3 ms  DynamicQuantities
      0.4 ms  DynamicQuantities → DynamicQuantitiesLinearAlgebraExt
  ```
  whereas with this PR I obtain
  ```julia
  julia> @time_imports using DynamicQuantities
      0.4 ms  Tricks
      0.3 ms  Compat
      0.4 ms  Compat → CompatLinearAlgebraExt
     44.1 ms  DynamicQuantities
      0.4 ms  DynamicQuantities → DynamicQuantitiesLinearAlgebraExt
  ```
- Removes the TOML dependency and its `using` statement: It's only used for extracting the version number from Project.toml, which IMO is a bit questionable. This feature is not used in the package, and if desired hardcoding the version number and adding a test for its consistency with Project.toml would be much simpler and faster. Generally, I have the feeling though that such a functionality (obtaining the version of an installed package) should rather be provided by Pkg or a Pkg utility package (I would assume such a package already exists?).
- Removes the weak dependency and test dependency on ScientificTypesBase: It is re-exported by ScientificTypes, so it is safe to access it via `ScientificTypes.ScientificTypesBase` since it can't be removed from ScientificTypes in a non-breaking release. This simplifies the dependency structure and the Requires hooks.