### PR TITLE
Remove SparseArrays dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "0.7.1"
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -213,7 +213,7 @@ function map_dimensions(op::O, l::SymbolicDimensions{L}, r::SymbolicDimensions{R
     while ir <= nr
         s = op(zero_L, nzvals_r[ir])
         if !iszero(s)
-            push!(I, op(nzdims_r[ir]))
+            push!(I, nzdims_r[ir])
             push!(V, s)
         end
         ir += 1

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -82,7 +82,7 @@ function Base.convert(::Type{Quantity{T,SymbolicDimensions{R}}}, q::Quantity{<:A
     return Quantity(convert(T, ustrip(q)), dims)
 end
 function Base.convert(::Type{Q}, q::Quantity{<:Any,<:SymbolicDimensions}) where {T,D<:Dimensions,Q<:Quantity{T,D}}
-    result = one(Q) * ustrip(q)
+    result = new_quantity(Q, ustrip(q), dim_type(Q))
     d = dimension(q)
     for (idx, value) in zip(getfield(d, :nzdims), getfield(d, :nzvals))
         if !iszero(value)

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -155,7 +155,7 @@ Base.iszero(d::SymbolicDimensions) = iszero(getfield(d, :nzvals))
 
 # Defines `inv(::SymbolicDimensions)` and `^(::SymbolicDimensions, ::Number)`
 function map_dimensions(op::Function, d::SymbolicDimensions)
-    return SymbolicDimensions(getfield(d, :nzdims), map(op, getfield(d, :nzvals)))
+    return SymbolicDimensions(copy(getfield(d, :nzdims)), map(op, getfield(d, :nzvals)))
 end
 
 # Defines `*(::SymbolicDimensions, ::SymbolicDimensions)` and `/(::SymbolicDimensions, ::SymbolicDimensions)`

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -71,15 +71,20 @@ end
 function Base.convert(::Type{Quantity{T,SymbolicDimensions}}, q::Quantity{<:Any,<:Dimensions}) where {T}
     return convert(Quantity{T,SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}}, q)
 end
-function Base.convert(::Type{Quantity{T,SymbolicDimensions{R}}}, q::Quantity{<:Any,<:Dimensions}) where {T,R}
-    syms = (:m, :kg, :s, :A, :K, :cd, :mol)
-    vals = (ulength(q), umass(q), utime(q), ucurrent(q), utemperature(q), uluminosity(q), uamount(q))
-    I = INDEX_TYPE[ALL_MAPPING[s] for (s, v) in zip(syms, vals) if !iszero(v)]
-    p = sortperm(I)
-    permute!(I, p)
-    V = R[tryrationalize(R, vals[i]) for i in p]
-    dims = SymbolicDimensions{R}(I, V)
-    return Quantity(convert(T, ustrip(q)), dims)
+function Base.convert(::Type{Q}, q::Quantity{<:Any,<:Dimensions}) where {T,R,Q<:Quantity{T,SymbolicDimensions{R}}}
+    return new_quantity(
+        Q,
+        convert(T, ustrip(q)),
+        SymbolicDimensions{R}(;
+            m=ulength(q),
+            kg=umass(q),
+            s=utime(q),
+            A=ucurrent(q),
+            K=utemperature(q),
+            cd=uluminosity(q),
+            mol=uamount(q),
+        )
+    )
 end
 function Base.convert(::Type{Q}, q::Quantity{<:Any,<:SymbolicDimensions}) where {T,D<:Dimensions,Q<:Quantity{T,D}}
     result = new_quantity(Q, ustrip(q), dim_type(Q))

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -106,29 +106,29 @@ expand_units(q::QuantityArray) = expand_units.(q)
 
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(getfield(d, :nzdims)), copy(getfield(d, :nzvals)))
 function Base.:(==)(l::SymbolicDimensions, r::SymbolicDimensions)
-    nzdimsl = getfield(l, :nzdims)
-    nzvalsl = getfield(l, :nzvals)
-    nzdimsr = getfield(r, :nzdims)
-    nzvalsr = getfield(r, :nzvals)
-    nl = length(nzdimsl)
-    nr = length(nzdimsr)
+    nzdims_l = getfield(l, :nzdims)
+    nzvals_l = getfield(l, :nzvals)
+    nzdims_r = getfield(r, :nzdims)
+    nzvals_r = getfield(r, :nzvals)
+    nl = length(nzdims_l)
+    nr = length(nzdims_r)
     il = ir = 1
     while il <= nl && ir <= nr
-        diml = nzdimsl[il]
-        dimr = nzdimsr[ir]
-        if diml == dimr
-            if nzvalsl[il] != nzvalsr[ir]
+        dim_l = nzdims_l[il]
+        dim_r = nzdims_r[ir]
+        if dim_l == dim_r
+            if nzvals_l[il] != nzvals_r[ir]
                 return false
             end
             il += 1
             ir += 1
-        elseif diml < dimr
-            if !iszero(nzvalsl[il])
+        elseif dim_l < dim_r
+            if !iszero(nzvals_l[il])
                 return false
             end
             il += 1
         else
-            if !iszero(nzvalsr[ir])
+            if !iszero(nzvals_r[ir])
                 return false
             end
             ir += 1
@@ -136,14 +136,14 @@ function Base.:(==)(l::SymbolicDimensions, r::SymbolicDimensions)
     end
 
     while il <= nl
-        if !iszero(nzvalsl[il])
+        if !iszero(nzvals_l[il])
             return false
         end
         il += 1
     end
 
     while ir <= nr
-        if !iszero(nzvalsr[ir])
+        if !iszero(nzvals_r[ir])
             return false
         end
         ir += 1
@@ -158,35 +158,35 @@ function _combine_vals(op::O, l::SymbolicDimensions{L}, r::SymbolicDimensions{R}
     T = typeof(op(zero(L), zero(R)))
     I = Vector{INDEX_TYPE}(undef, 0)
     V = Vector{T}(undef, 0)
-    nzdimsl = getfield(l, :nzdims)
-    nzvalsl = getfield(l, :nzvals)
-    nzdimsr = getfield(r, :nzdims)
-    nzvalsr = getfield(r, :nzvals)
-    nl = length(nzdimsl)
-    nr = length(nzdimsr)
+    nzdims_l = getfield(l, :nzdims)
+    nzvals_l = getfield(l, :nzvals)
+    nzdims_r = getfield(r, :nzdims)
+    nzvals_r = getfield(r, :nzvals)
+    nl = length(nzdims_l)
+    nr = length(nzdims_r)
     il = ir = 1
     while il <= nl && ir <= nr
-        diml = nzdimsl[il]
-        dimr = nzdimsr[ir]
-        if diml == dimr
-            s = op(nzvalsl[il], nzvalsr[ir])
+        dim_l = nzdims_l[il]
+        dim_r = nzdims_r[ir]
+        if dim_l == dim_r
+            s = op(nzvals_l[il], nzvals_r[ir])
             if !iszero(s)
-                push!(I, diml)
+                push!(I, dim_l)
                 push!(V, s)
             end
             il += 1
             ir += 1
-        elseif diml < dimr
-            s = nzvalsl[il]
+        elseif dim_l < dim_r
+            s = nzvals_l[il]
             if !iszero(s)
-                push!(I, diml)
+                push!(I, dim_l)
                 push!(V, s)
             end
             il += 1
         else
-            s = op(nzvalsr[ir])
+            s = op(nzvals_r[ir])
             if !iszero(s)
-                push!(I, dimr)
+                push!(I, dim_r)
                 push!(V, s)
             end
             ir += 1
@@ -194,18 +194,18 @@ function _combine_vals(op::O, l::SymbolicDimensions{L}, r::SymbolicDimensions{R}
     end
 
     while il <= nl
-        s = nzvalsl[il]
+        s = nzvals_l[il]
         if !iszero(s)
-            push!(I, nzdimsl[il])
+            push!(I, nzdims_l[il])
             push!(V, s)
         end
         il += 1
     end
 
     while ir <= nr
-        s = nzvalsr[ir]
+        s = nzvals_r[ir]
         if !iszero(s)
-            push!(I, op(nzdimsr[ir]))
+            push!(I, op(nzdims_r[ir]))
             push!(V, s)
         end
         ir += 1

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -42,7 +42,8 @@ end
 static_fieldnames(::Type{<:SymbolicDimensions}) = ALL_SYMBOLS
 function Base.getproperty(d::SymbolicDimensions{R}, s::Symbol) where {R}
     nzdims = getfield(d, :nzdims)
-    i = ALL_MAPPING[s]
+    i = get(ALL_MAPPING, s, INDEX_TYPE(0))
+    iszero(i) && error("$s is not available as a symbol in SymbolicDimensions. Symbols available: $(ALL_SYMBOLS).")
     ii = searchsortedfirst(nzdims, i)
     if ii <= length(nzdims) && nzdims[ii] == i
         return getfield(d, :nzvals)[ii]

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -498,6 +498,49 @@ end
 end
 
 @testset "Symbolic dimensions" begin
+    # TODO: Remove constructors for sym3 and sym4s?
+    sym1 = @inferred(SymbolicDimensions(; m = 3, s = -1))
+    sym2 = @inferred(SymbolicDimensions{Rational{Int}}(; m = 3, s = -1))
+    sym3 = @inferred(SymbolicDimensions(Rational{Int}; m = 3, s = -1))
+    sym4 = @inferred(SymbolicDimensions{Int}(Rational{Int}; m = 3, s = -1))
+    for (sym, T) in (
+        (sym1, DynamicQuantities.DEFAULT_DIM_BASE_TYPE), (sym2, Rational{Int}), (sym3, Rational{Int}), (sym4, Rational{Int}),
+    )  
+        @test sym isa SymbolicDimensions{T}
+
+        # Properties
+        @test sym.m == 3
+        @test sym.s == -1
+        @test propertynames(sym) == DynamicQuantities.ALL_SYMBOLS
+        @test issubset((:m, :s), propertynames(sym))
+        @test all(propertynames(sym)) do x
+            val = getproperty(sym, x)
+            return x === :m ? val == 3 : (x === :s ? val == -1 : iszero(val))
+        end
+
+        # Internal constructor
+        @test DynamicQuantities.constructor_of(typeof(sym)) === SymbolicDimensions
+
+        # Equality comparisons
+        @test sym == sym
+        @test sym == copy(sym)
+        @test sym !== copy(sym)
+        @test sym == SymbolicDimensions{Int}(; m = 3, s = -1)
+        @test SymbolicDimensions{Int}(; m = 3, s = -1) == sym
+        @test sym == SymbolicDimensions(; m = 3, g = 0, s = -1)
+        @test SymbolicDimensions(; m = 3, g = 0, s = -1) == sym
+        @test sym == SymbolicDimensions(; m = 3, s = -1, K = 0)
+        @test SymbolicDimensions(; m = 3, s = -1, K = 0) == sym
+        @test sym != SymbolicDimensions(; m = 2, s = -1)
+        @test SymbolicDimensions(; m = 2, s = -1) != sym
+        @test sym != SymbolicDimensions(; m = 3, g = 1, s = -1)
+        @test SymbolicDimensions(; m = 3, g = 1, s = -1) != sym
+        @test sym != SymbolicDimensions(; m = 3, s = -1, K = 1)
+        @test SymbolicDimensions(; m = 3, s = -1, K = 1) != sym
+
+        @test !iszero(sym)
+    end
+
     q = 1.5us"km/s"
     @test q == 1.5 * us"km" / us"s"
     @test typeof(q) <: Quantity{Float64,<:SymbolicDimensions}

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -580,8 +580,10 @@ end
 
     # Test conversion
     @test typeof(SymbolicDimensions{Rational{Int}}(dimension(us"km/s"))) == SymbolicDimensions{Rational{Int}}
-    @test convert(Quantity{Float64,SymbolicDimensions}, u"kg") == us"1kg"
-    @test convert(Quantity{Float64,Dimensions}, us"3.5kg/s") == u"3.5kg/s"
+    @test convert(Quantity{Float64,SymbolicDimensions}, u"kg") == 1.0us"kg"
+    @test convert(Quantity{Float64,SymbolicDimensions}, u"cm") == 1e-2us"m"
+    @test convert(Quantity{Float64,Dimensions}, 3.5us"kg/s") == 3.5u"kg/s"
+    @test convert(Quantity{Float64,Dimensions}, 3.5us"Constants.pc") == 3.5u"Constants.pc"
 
     # Helpful error if symbol not found:
     sym5 = dimension(us"km/s")

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -580,6 +580,11 @@ end
 
     # Test conversion
     @test typeof(SymbolicDimensions{Rational{Int}}(dimension(us"km/s"))) == SymbolicDimensions{Rational{Int}}
+
+    # Helpful error if symbol not found:
+    sym5 = dimension(us"km/s")
+    VERSION >= v"1.8" &&
+        @test_throws "rad is not available as a symbol" sym5.rad
 end
 
 @testset "Test ambiguities" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -499,10 +499,10 @@ end
 
 @testset "Symbolic dimensions" begin
     # TODO: Remove constructors for sym3 and sym4s?
-    sym1 = @inferred(SymbolicDimensions(; m = 3, s = -1))
-    sym2 = @inferred(SymbolicDimensions{Rational{Int}}(; m = 3, s = -1))
-    sym3 = @inferred(SymbolicDimensions(Rational{Int}; m = 3, s = -1))
-    sym4 = @inferred(SymbolicDimensions{Int}(Rational{Int}; m = 3, s = -1))
+    sym1 = @inferred(SymbolicDimensions(; m=3, s=-1))
+    sym2 = @inferred(SymbolicDimensions{Rational{Int}}(; m=3, s=-1))
+    sym3 = @inferred(SymbolicDimensions(Rational{Int}; m=3, s=-1))
+    sym4 = @inferred(SymbolicDimensions{Int}(Rational{Int}; m=3, s=-1))
     for (sym, T) in (
         (sym1, DynamicQuantities.DEFAULT_DIM_BASE_TYPE), (sym2, Rational{Int}), (sym3, Rational{Int}), (sym4, Rational{Int}),
     )  
@@ -525,18 +525,18 @@ end
         @test sym == sym
         @test sym == copy(sym)
         @test sym !== copy(sym)
-        @test sym == SymbolicDimensions{Int}(; m = 3, s = -1)
-        @test SymbolicDimensions{Int}(; m = 3, s = -1) == sym
-        @test sym == SymbolicDimensions(; m = 3, g = 0, s = -1)
-        @test SymbolicDimensions(; m = 3, g = 0, s = -1) == sym
-        @test sym == SymbolicDimensions(; m = 3, s = -1, K = 0)
-        @test SymbolicDimensions(; m = 3, s = -1, K = 0) == sym
-        @test sym != SymbolicDimensions(; m = 2, s = -1)
-        @test SymbolicDimensions(; m = 2, s = -1) != sym
-        @test sym != SymbolicDimensions(; m = 3, g = 1, s = -1)
-        @test SymbolicDimensions(; m = 3, g = 1, s = -1) != sym
-        @test sym != SymbolicDimensions(; m = 3, s = -1, K = 1)
-        @test SymbolicDimensions(; m = 3, s = -1, K = 1) != sym
+        @test sym == SymbolicDimensions{Int}(; m=3, s=-1)
+        @test SymbolicDimensions{Int}(; m=3, s=-1) == sym
+        @test sym == SymbolicDimensions(; m=3, g=0, s=-1)
+        @test SymbolicDimensions(; m=3, g=0, s=-1) == sym
+        @test sym == SymbolicDimensions(; m=3, s=-1, K=0)
+        @test SymbolicDimensions(; m=3, s=-1, K=0) == sym
+        @test sym != SymbolicDimensions(; m=2, s=-1)
+        @test SymbolicDimensions(; m=2, s=-1) != sym
+        @test sym != SymbolicDimensions(; m=3, g=1, s=-1)
+        @test SymbolicDimensions(; m=3, g=1, s=-1) != sym
+        @test sym != SymbolicDimensions(; m=3, s=-1, K=1)
+        @test SymbolicDimensions(; m=3, s=-1, K=1) != sym
 
         @test !iszero(sym)
     end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -580,6 +580,8 @@ end
 
     # Test conversion
     @test typeof(SymbolicDimensions{Rational{Int}}(dimension(us"km/s"))) == SymbolicDimensions{Rational{Int}}
+    @test convert(Quantity{Float64,SymbolicDimensions}, u"kg") == us"1kg"
+    @test convert(Quantity{Float64,Dimensions}, us"3.5kg/s") == u"3.5kg/s"
 
     # Helpful error if symbol not found:
     sym5 = dimension(us"km/s")


### PR DESCRIPTION
This PR removes the SparseArrays dependency completely.

Only the implementation of `==` and `+`/`-` required a bit more code, otherwise not too many changes were needed.

Fixes #53.