### PR TITLE
Warn user about precompilation of symbolic units

### DIFF
--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -589,6 +589,14 @@ end
     sym5 = dimension(us"km/s")
     VERSION >= v"1.8" &&
         @test_throws "rad is not available as a symbol" sym5.rad
+
+    # Extra test coverage
+    @test_warn(
+        "Creating SymbolicDimensions objects",
+        DynamicQuantities.SymbolicUnitsParse._generate_unit_symbols(
+            testing=Val(true)
+        )
+    )
 end
 
 @testset "Test ambiguities" begin


### PR DESCRIPTION
As noted in #51 by @cadojo, `SymbolicDimensions` parsing is not compatible with precompilation because the unit and constant variables are only created at runtime. (The reason for this is that it can take about a second to generate all the symbols. So, to keep startup time small for performant libraries, the symbolic dimensions are generated at runtime.)

This PR:

1. Prevents the creation of the unit symbols/constants if the user happens to trigger this, by exiting `_generate_unit_symbols` is precompilation is active.
2. Prints a helpful warning to the user:

> Creating SymbolicDimensions objects during precompilation is not allowed, as symbolic units are not created until the first runtime call. You should use regular `Dimensions` instead for computations, and generally use `SymbolicDimensions` for display purposes. If needed, you can manually create `SymbolicDimensions` by calling the constructor explicitly, such as `Quantity(1.5, SymbolicDimensions; km=1, s=-1)`, which is equivalent to `1.5us"km/s"`.

What do you think @cadojo?

cc @gaurav-arya 