### PR TITLE
Add `uconvert` method for `QuantityArray`

### DIFF
--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -123,6 +123,7 @@ function uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}, q::Abstra
     return new_quantity(typeof(q), new_val, new_dim)
 end
 function uconvert(qout::AbstractQuantity{<:Any,<:SymbolicDimensions}, q::QuantityArray{<:Any,<:Any,<:Dimensions})
+    @assert isone(ustrip(qout)) "You passed a quantity with a non-unit value to uconvert."
     qout_expanded = expand_units(qout)
     dimension(q) == dimension(qout_expanded) || throw(DimensionError(q, qout_expanded))
     new_array = ustrip(q) ./ ustrip(qout_expanded)

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -106,6 +106,7 @@ function expand_units(q::Q) where {T,R,D<:SymbolicDimensions{R},Q<:AbstractQuant
     return convert(constructor_of(Q){T,Dimensions{R}}, q)
 end
 expand_units(q::QuantityArray) = expand_units.(q)
+# TODO: Make the array-based one more efficient
 
 """
     uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}, q::AbstractQuantity{<:Any, <:Dimensions})
@@ -121,6 +122,14 @@ function uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions}, q::Abstra
     new_dim = dimension(qout)
     return new_quantity(typeof(q), new_val, new_dim)
 end
+function uconvert(qout::AbstractQuantity{<:Any,<:SymbolicDimensions}, q::QuantityArray{<:Any,<:Any,<:Dimensions})
+    qout_expanded = expand_units(qout)
+    dimension(q) == dimension(qout_expanded) || throw(DimensionError(q, qout_expanded))
+    new_array = ustrip(q) ./ ustrip(qout_expanded)
+    new_dim = dimension(qout)
+    return QuantityArray(new_array, new_dim, quantity_type(q))
+end
+# TODO: Method for converting SymbolicDimensions -> SymbolicDimensions
 
 """
     uconvert(qout::AbstractQuantity{<:Any, <:SymbolicDimensions})

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -613,6 +613,22 @@ end
     qs = uconvert(convert(Quantity{Float16}, us"g"), 5 * q)
     @test typeof(qs) <: Quantity{Float16,<:SymbolicDimensions{<:Any}}
     @test qs ≈ 7.5us"g"
+
+    # Arrays
+    x = [1.0, 2.0, 3.0] .* u"kg"
+    xs = x .|> uconvert(us"g")
+    @test typeof(xs) <: Vector{<:Quantity{Float64,<:SymbolicDimensions{<:Any}}}
+    @test xs[2] ≈ 2000us"g"
+
+    x_qa = QuantityArray(x)
+    xs_qa = x_qa .|> uconvert(us"g")
+    @test typeof(xs_qa) <: QuantityArray{Float64,1,<:SymbolicDimensions{<:Any}}
+    @test xs_qa[2] ≈ 2000us"g"
+
+    # Without vectorized call:
+    xs_qa2 = x_qa |> uconvert(us"g")
+    @test typeof(xs_qa2) <: QuantityArray{Float64,1,<:SymbolicDimensions{<:Any}}
+    @test xs_qa2[2] ≈ 2000us"g"
 end
 
 @testset "Test ambiguities" begin


### PR DESCRIPTION
cc @gaurav-arya

(For what it's worth, it seems like using `uconvert(us"km").(array)` works, but it relies on compiler inlining a lot of stuff to be as efficient. Also, `expand_units` has a dedicated method, so I think it makes sense to do it here as well.)