### PR TITLE
WIP: add methods for soft promotion

### DIFF
--- a/ext/DynamicQuantitiesMeasurementsExt.jl
+++ b/ext/DynamicQuantitiesMeasurementsExt.jl
@@ -1,10 +1,10 @@
 module DynamicQuantitiesMeasurementsExt
 
-using DynamicQuantities: AbstractQuantity, new_quantity, dimension, ustrip, DimensionError
+using DynamicQuantities: AbstractQuantity, new_quantity, dimension, ustrip, dimension_promote
 using Measurements: Measurements, measurement, value, uncertainty
 
 function Measurements.measurement(a::Q, b::Q) where {Q<:AbstractQuantity}
-    dimension(a) == dimension(b) || throw(DimensionError(a, b))
+    a, b = dimension_promote(a, b)
     raw_measurement = measurement(ustrip(a), ustrip(b))
     return new_quantity(Q, raw_measurement, dimension(a))
 end

--- a/src/math.jl
+++ b/src/math.jl
@@ -18,7 +18,7 @@ Base.:/(l, r::AbstractDimensions) = error("Please use an `AbstractQuantity` for 
 
 Base.:+(l::AbstractQuantity, r::AbstractQuantity) =
     let
-        dimension(l) == dimension(r) || throw(DimensionError(l, r))
+        l, r = dimension_promote(l, r)
         new_quantity(typeof(l), ustrip(l) + ustrip(r), dimension(l))
     end
 Base.:-(l::AbstractQuantity) = new_quantity(typeof(l), -ustrip(l), dimension(l))
@@ -26,12 +26,12 @@ Base.:-(l::AbstractQuantity, r::AbstractQuantity) = l + (-r)
 
 Base.:+(l::AbstractQuantity, r) =
     let
-        iszero(dimension(l)) || throw(DimensionError(l, r))
+        l, r = dimension_promote(l, r)
         new_quantity(typeof(l), ustrip(l) + r, dimension(l))
     end
 Base.:+(l, r::AbstractQuantity) =
     let
-        iszero(dimension(r)) || throw(DimensionError(l, r))
+        l, r = dimension_promote(l, r)
         new_quantity(typeof(r), l + ustrip(r), dimension(r))
     end
 Base.:-(l::AbstractQuantity, r) = l + (-r)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,11 +59,11 @@ function Base.isapprox(l::AbstractQuantity, r::AbstractQuantity; kws...)
     return isapprox(ustrip(l), ustrip(r); kws...) && dimension(l) == dimension(r)
 end
 function Base.isapprox(l, r::AbstractQuantity; kws...)
-    iszero(dimension(r)) || throw(DimensionError(l, r))
+    l, r = dimension_promote(l, r)
     return isapprox(l, ustrip(r); kws...)
 end
 function Base.isapprox(l::AbstractQuantity, r; kws...)
-    iszero(dimension(l)) || throw(DimensionError(l, r))
+    l, r = dimension_promote(l, r)
     return isapprox(ustrip(l), r; kws...)
 end
 Base.iszero(d::AbstractDimensions) = all_dimensions(iszero, d)
@@ -72,15 +72,15 @@ Base.:(==)(l::AbstractQuantity, r::AbstractQuantity) = ustrip(l) == ustrip(r) &&
 Base.:(==)(l, r::AbstractQuantity) = ustrip(l) == ustrip(r) && iszero(dimension(r))
 Base.:(==)(l::AbstractQuantity, r) = ustrip(l) == ustrip(r) && iszero(dimension(l))
 function Base.isless(l::AbstractQuantity, r::AbstractQuantity)
-    dimension(l) == dimension(r) || throw(DimensionError(l, r))
+    l, r = dimension_promote(l, r)
     return isless(ustrip(l), ustrip(r))
 end
 function Base.isless(l::AbstractQuantity, r)
-    iszero(dimension(l)) || throw(DimensionError(l, r))
+    l, r = dimension_promote(l, r)
     return isless(ustrip(l), r)
 end
 function Base.isless(l, r::AbstractQuantity)
-    iszero(dimension(r)) || throw(DimensionError(l, r))
+    l, r = dimension_promote(l, r)
     return isless(l, ustrip(r))
 end
 
@@ -267,3 +267,19 @@ Get the amount dimension of a quantity (e.g., mol^(uamount)).
 """
 uamount(q::AbstractQuantity) = uamount(dimension(q))
 uamount(d::AbstractDimensions) = d.amount
+
+
+"""This function allows custom behavior for dimensionality analysis"""
+@inline function dimension_promote(l::AbstractQuantity, r::AbstractQuantity)
+    dimension(l) == dimension(r) || throw(DimensionError(l, r))
+    return l, r
+end
+@inline function dimension_promote(l::AbstractQuantity, r)
+    iszero(dimension(l)) || throw(DimensionError(l, r))
+    return l, r
+end
+@inline function dimension_promote(l, r::AbstractQuantity)
+    iszero(dimension(r)) || throw(DimensionError(l, r))
+    return l, r
+end
+# TODO: May want to have methods for arrays as well

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -615,6 +615,15 @@ end
     @test qs ≈ 7.5us"g"
 end
 
+@testset "Soft conversion" begin
+    x = 1.5us"km"
+    y = 1.5us"m"
+    @test x + y == 1.5015us"km"
+    @test y + x == 1501.5us"m"
+
+    # TODO: Should allow `==` for non-equal dimensions
+end
+
 @testset "Test ambiguities" begin
     R = DEFAULT_DIM_BASE_TYPE
     x = convert(R, 10)


### PR DESCRIPTION
cc @gaurav-arya

This makes it so that you can add `1.5us"km"` with `1500us"m"` and there won't be a dimension error. It will choose to convert to the leftmost dimension.

I'm not sure if that's the best thing to do though (maybe we should force users to stay in the same dimensions), so any thoughts appreciated!

e.g., this would make your chemistry example possible with symbolic dimensions throughout. You could add `J` and `eV` and not have it be converted to SI units.