### PR TITLE
Reduce the number of method invalidations

### DIFF
--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -78,13 +78,13 @@ end
 function Base.promote_rule(::Type{<:FixedRational{T1}}, ::Type{Rational{T2}}) where {T1,T2}
     return Rational{promote_type(T1,T2)}
 end
-function Base.promote_rule(::Type{<:FixedRational{T1}}, ::Type{T2}) where {T1,T2}
+function Base.promote_rule(::Type{<:FixedRational{T1}}, ::Type{T2}) where {T1,T2<:Real}
     return promote_type(Rational{T1}, T2)
 end
-
-# Want to consume integers:
-Base.promote(x::Integer, y::F) where {F<:FixedRational} = (F(x), y)
-Base.promote(x::F, y::Integer) where {F<:FixedRational} = reverse(promote(y, x))
+function Base.promote_rule(::Type{F}, ::Type{<:Integer}) where {F<:FixedRational}
+    # Want to consume integers:
+    return F
+end
 
 Base.string(x::FixedRational) =
     let
@@ -93,7 +93,6 @@ Base.string(x::FixedRational) =
         return string(div(x.num, g)) * "//" * string(div(denom(x), g))
     end
 Base.show(io::IO, x::FixedRational) = print(io, string(x))
-Base.zero(::Type{F}) where {F<:FixedRational} = unsafe_fixed_rational(0, eltype(F), val_denom(F))
 
 tryrationalize(::Type{F}, x::F) where {F<:FixedRational} = x
 tryrationalize(::Type{F}, x::Union{Rational,Integer}) where {F<:FixedRational} = convert(F, x)

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -64,7 +64,7 @@ Rational(x::F) where {F<:FixedRational} = Rational{eltype(F)}(x)
         isinteger(x) || throw(InexactError(:convert, I, x))
         convert(I, div(x.num, denom(F)))
     end
-Bool(x::F) where {F<:FixedRational} =
+(::Type{Bool})(x::F) where {F<:FixedRational} =
     let
         iszero(x) || isone(x) || throw(InexactError(:convert, Bool, x))
         return x.num == denom(F)

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -55,14 +55,21 @@ end
 Base.iszero(x::FixedRational) = iszero(x.num)
 Base.isone(x::F) where {F<:FixedRational} = x.num == denom(F)
 Base.isinteger(x::F) where {F<:FixedRational} = iszero(x.num % denom(F))
-Base.convert(::Type{Rational{R}}, x::F) where {R,F<:FixedRational} = Rational{R}(x.num, denom(F))
-Base.convert(::Type{Rational}, x::F) where {F<:FixedRational} = Rational{eltype(F)}(x.num, denom(F))
-Base.convert(::Type{AF}, x::F) where {AF<:AbstractFloat,F<:FixedRational} = convert(AF, x.num) / convert(AF, denom(F))
-Base.convert(::Type{I}, x::F) where {I<:Integer,F<:FixedRational} =
+
+Rational{R}(x::F) where {R,F<:FixedRational} = Rational{R}(x.num, denom(F))
+Rational(x::F) where {F<:FixedRational} = Rational{eltype(F)}(x)
+(::Type{AF})(x::F) where {AF<:AbstractFloat,F<:FixedRational} = convert(AF, x.num) / convert(AF, denom(F))
+(::Type{I})(x::F) where {I<:Integer,F<:FixedRational} =
     let
         isinteger(x) || throw(InexactError(:convert, I, x))
         convert(I, div(x.num, denom(F)))
     end
+Bool(x::F) where {F<:FixedRational} =
+    let
+        iszero(x) || isone(x) || throw(InexactError(:convert, Bool, x))
+        return x.num == denom(F)
+    end
+
 Base.round(::Type{T}, x::F, r::RoundingMode=RoundNearest) where {T,F<:FixedRational} = div(convert(T, x.num), convert(T, denom(F)), r)
 Base.decompose(x::F) where {T,F<:FixedRational{T}} = (x.num, zero(T), denom(F))
 

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -55,8 +55,6 @@ end
 Base.iszero(x::FixedRational) = iszero(x.num)
 Base.isone(x::F) where {F<:FixedRational} = x.num == denom(F)
 Base.isinteger(x::F) where {F<:FixedRational} = iszero(x.num % denom(F))
-Base.convert(::Type{F}, x::Integer) where {F<:FixedRational} = unsafe_fixed_rational(x * denom(F), eltype(F), val_denom(F))
-Base.convert(::Type{F}, x::Rational) where {F<:FixedRational} = F(x)
 Base.convert(::Type{Rational{R}}, x::F) where {R,F<:FixedRational} = Rational{R}(x.num, denom(F))
 Base.convert(::Type{Rational}, x::F) where {F<:FixedRational} = Rational{eltype(F)}(x.num, denom(F))
 Base.convert(::Type{AF}, x::F) where {AF<:AbstractFloat,F<:FixedRational} = convert(AF, x.num) / convert(AF, denom(F))

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -420,7 +420,7 @@ end
     @test promote(f64, f8) == (2, 2)
     @test typeof(promote(f64, f8)) == typeof((f64, f64))
     @test typeof(promote(FixedRational{Int8,10}(2), FixedRational{Int8,10}(2))) == typeof((f8, f8))
-    @test typeof(promote(1.6, f64)) == typeof((1.6, 1.6))
+    @test promote_type(Float64, typeof(f64)) == Float64
 
     # Required to hit integer branch (otherwise will go to `literal_pow`)
     f(i::Int) = Dimensions(length=1, mass=-1)^i

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -407,6 +407,11 @@ end
 @testset "Additional tests of FixedRational" begin
     @test convert(Int64, FixedRational{Int64,1000}(2 // 1)) == 2
     @test convert(Int32, FixedRational{Int64,1000}(3 // 1)) == 3
+    @test convert(Bool, FixedRational{Int8,6}(1//1)) === true
+    @test convert(Bool, FixedRational{Int8,6}(0//1)) === false
+
+    @test_throws InexactError convert(Int32, FixedRational{Int8,6}(2//3))
+    @test_throws InexactError convert(Bool, FixedRational{Int8,6}(2//1))
 
     VERSION >= v"1.8" && @test_throws "Refusing to" promote(FixedRational{Int,10}(2), FixedRational{Int,4}(2))
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -420,6 +420,7 @@ end
     @test promote(f64, f8) == (2, 2)
     @test typeof(promote(f64, f8)) == typeof((f64, f64))
     @test typeof(promote(FixedRational{Int8,10}(2), FixedRational{Int8,10}(2))) == typeof((f8, f8))
+    @test typeof(promote(1.6, f64)) == typeof((1.6, 1.6))
 
     # Required to hit integer branch (otherwise will go to `literal_pow`)
     f(i::Int) = Dimensions(length=1, mass=-1)^i

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -438,7 +438,7 @@ end
     # Promotion rules
     @test promote_type(FixedRational{Int64,10},FixedRational{BigInt,10}) == FixedRational{BigInt,10}
     @test promote_type(Rational{Int8}, FixedRational{Int,12345}) == Rational{Int}
-    @test promote_type(Int8, FixedRational{Int,12345}) == promote_type(Int8, Rational{Int})
+    @test promote_type(Int8, FixedRational{Int,12345}) == FixedRational{Int,12345}
 end
 
 @testset "Quantity promotion" begin


### PR DESCRIPTION
See https://julialang.org/blog/2020/08/invalidations/

According to SnoopCompile, the last remaining method invalidation on Julia 1.10 is `Base.:+(l::Any, r::AbstractGenericQuantity)`:

```julia
julia> using SnoopCompileCore

julia> invalidations = @snoopr begin
           using DynamicQuantities
       end;

julia> using SnoopCompile

julia> trees = invalidation_trees(invalidations)
1-element Vector{SnoopCompile.MethodInvalidations}:
 inserting +(l, r::AbstractGenericQuantity) @ DynamicQuantities ~/Documents/DynamicQuantities.jl/src/math.jl:35 invalidated:
   mt_backedges: 1: signature Tuple{typeof(+), Ptr{UInt16}, Any} triggered MethodInstance for Base._copyfrompacked!(::Ptr, ::Ptr{UInt16}) (1 children)
                 2: signature Tuple{typeof(+), Ptr{Tuple{UInt8, UInt8}}, Any} triggered MethodInstance for Base._copyfrompacked!(::Ptr, ::Ptr{Tuple{UInt8, UInt8}}) (1 children)
                 3: signature Tuple{typeof(+), Ptr{UInt8}, Any} triggered MethodInstance for Base.GMP.var"#string#4"(::Int64, ::Integer, ::typeof(string), ::BigInt) (3 children)

```

I don't see any way of fixing this invalidation, so we should probably leave it at that.

Fixes #67 