### PR TITLE
Switch to using ConstructionBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.7.5"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
 Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
@@ -22,6 +23,7 @@ DynamicQuantitiesUnitfulExt = "Unitful"
 
 [compat]
 Compat = "3.42, 4"
+ConstructionBase = "1"
 Measurements = "2"
 PackageExtensionCompat = "1.0.2"
 ScientificTypes = "3"

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -31,7 +31,7 @@ struct QuantityArray{T,N,D<:AbstractDimensions,Q<:AbstractUnionQuantity{T,D},V<:
     dimensions::D
 
     function QuantityArray(v::_V, d::_D, ::Type{_Q}) where {_T,_N,_D<:AbstractDimensions,_Q<:AbstractUnionQuantity,_V<:AbstractArray{_T,_N}}
-        Q_out = constructor_of(_Q){_T,_D}
+        Q_out = constructorof(_Q){_T,_D}
         return new{_T,_N,_D,Q_out,_V}(v, d)
     end
 end
@@ -74,7 +74,7 @@ function Base.convert(::Type{QA1}, A::QA2) where {QA1<:QuantityArray,QA2<:Quanti
     N = ndims(QA1)
 
     raw_array = Base.Fix1(convert, Q).(A)
-    output = QuantityArray(convert(constructor_of(V){Q,N}, raw_array))
+    output = QuantityArray(convert(constructorof(V){Q,N}, raw_array))
     # TODO: This will mess with static arrays
 
     return output::QA1

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -1,3 +1,6 @@
+import ConstructionBase: constructorof
+import Tricks: static_fieldnames
+
 import .Units: UNIT_SYMBOLS, UNIT_MAPPING, UNIT_VALUES
 import .Constants: CONSTANT_SYMBOLS, CONSTANT_MAPPING, CONSTANT_VALUES
 
@@ -53,7 +56,7 @@ function Base.getproperty(d::SymbolicDimensions{R}, s::Symbol) where {R}
 end
 Base.propertynames(::SymbolicDimensions) = ALL_SYMBOLS
 Base.getindex(d::SymbolicDimensions, k::Symbol) = getproperty(d, k)
-constructor_of(::Type{<:SymbolicDimensions}) = SymbolicDimensions
+constructorof(::Type{<:SymbolicDimensions}) = SymbolicDimensions
 
 SymbolicDimensions{R}(d::SymbolicDimensions) where {R} = SymbolicDimensions{R}(getfield(d, :nzdims), convert(Vector{R}, getfield(d, :nzvals)))
 SymbolicDimensions(; kws...) = SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}(; kws...)
@@ -71,7 +74,7 @@ end
 for (type, _) in ABSTRACT_QUANTITY_TYPES
     @eval begin
         function Base.convert(::Type{Q}, q::AbstractUnionQuantity{<:Any,<:Dimensions}) where {T,Q<:$type{T,SymbolicDimensions}}
-            return convert(constructor_of(Q){T,SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}}, q)
+            return convert(constructorof(Q){T,SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}}, q)
         end
         function Base.convert(::Type{Q}, q::AbstractUnionQuantity{<:Any,<:Dimensions}) where {T,R,Q<:$type{T,SymbolicDimensions{R}}}
             syms = (:m, :kg, :s, :A, :K, :cd, :mol)
@@ -82,14 +85,14 @@ for (type, _) in ABSTRACT_QUANTITY_TYPES
             permute!(I, p)
             permute!(V, p)
             dims = SymbolicDimensions{R}(I, V)
-            return constructor_of(Q)(convert(T, ustrip(q)), dims)
+            return constructorof(Q)(convert(T, ustrip(q)), dims)
         end
         function Base.convert(::Type{Q}, q::AbstractUnionQuantity{<:Any,<:SymbolicDimensions}) where {T,D<:Dimensions,Q<:$type{T,D}}
-            result = constructor_of(Q)(T(ustrip(q)), D())
+            result = constructorof(Q)(T(ustrip(q)), D())
             d = dimension(q)
             for (idx, value) in zip(getfield(d, :nzdims), getfield(d, :nzvals))
                 if !iszero(value)
-                    result = result * convert(constructor_of(Q){T,D}, ALL_VALUES[idx]) ^ value
+                    result = result * convert(constructorof(Q){T,D}, ALL_VALUES[idx]) ^ value
                 end
             end
             return result
@@ -108,7 +111,7 @@ for converting to specific symbolic units, or `convert(Quantity{<:Any,<:Symbolic
 for assuming SI units as the output symbols.
 """
 function uexpand(q::Q) where {T,R,D<:SymbolicDimensions{R},Q<:AbstractQuantity{T,D}}
-    return convert(constructor_of(Q){T,Dimensions{R}}, q)
+    return convert(constructorof(Q){T,Dimensions{R}}, q)
 end
 uexpand(q::QuantityArray) = uexpand.(q)
 # TODO: Make the array-based one more efficient

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,5 +1,6 @@
-import Tricks: static_fieldnames
 import Compat: allequal
+import ConstructionBase: constructorof
+import Tricks: static_fieldnames
 
 function map_dimensions(f::F, args::AbstractDimensions...) where {F<:Function}
     dimension_type = promote_type(typeof(args).parameters...)
@@ -116,8 +117,8 @@ end
 for f in (:one, :typemin, :typemax)
     @eval begin
         Base.$f(::Type{Q}) where {T,D,Q<:AbstractUnionQuantity{T,D}} = new_quantity(Q, $f(T), D)
-        Base.$f(::Type{Q}) where {T,Q<:AbstractUnionQuantity{T}} = $f(constructor_of(Q){T, DEFAULT_DIM_TYPE})
-        Base.$f(::Type{Q}) where {Q<:AbstractUnionQuantity} = $f(Q{DEFAULT_VALUE_TYPE, DEFAULT_DIM_TYPE})
+        Base.$f(::Type{Q}) where {T,Q<:AbstractUnionQuantity{T}} = $f(constructorof(Q){T, DEFAULT_DIM_TYPE})
+        Base.$f(::Type{Q}) where {Q<:AbstractUnionQuantity} = $f(constructorof(Q){DEFAULT_VALUE_TYPE, DEFAULT_DIM_TYPE})
     end
     if f == :one  # Return empty dimensions, as should be multiplicative identity.
         @eval Base.$f(q::Q) where {Q<:AbstractUnionQuantity} = new_quantity(Q, $f(ustrip(q)), one(dimension(q)))

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -534,7 +534,7 @@ end
         end
 
         # Internal constructor
-        @test DynamicQuantities.constructor_of(typeof(sym)) === SymbolicDimensions
+        @test DynamicQuantities.constructorof(typeof(sym)) === SymbolicDimensions
 
         # Equality comparisons
         @test sym == sym


### PR DESCRIPTION
Rather than using our own function for `constructorof`, just use the one in ConstructionBase.jl, so (1) the code is more readable, and (2) the behavior is easier to overload.

@devmotion (I think you suggested this in maybe #54?)