### PR TITLE
Add RecursiveArrayTools.jl extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,12 +11,14 @@ Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 [weakdeps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
 DynamicQuantitiesLinearAlgebraExt = "LinearAlgebra"
 DynamicQuantitiesMeasurementsExt = "Measurements"
+DynamicQuantitiesRecursiveArrayToolsExt = "RecursiveArrayTools"
 DynamicQuantitiesScientificTypesExt = "ScientificTypes"
 DynamicQuantitiesUnitfulExt = "Unitful"
 
@@ -24,6 +26,7 @@ DynamicQuantitiesUnitfulExt = "Unitful"
 Compat = "3.42, 4"
 Measurements = "2"
 PackageExtensionCompat = "1.0.2"
+RecursiveArrayTools = "2"
 ScientificTypes = "3"
 Tricks = "0.1"
 Unitful = "1"
@@ -34,6 +37,7 @@ Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 Ratios = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
+RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SaferIntegers = "88634af6-177f-5301-88b8-7819386cfa38"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
@@ -42,4 +46,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Aqua", "LinearAlgebra", "Measurements", "Ratios", "SaferIntegers", "SafeTestsets", "ScientificTypes", "StaticArrays", "Test", "Unitful"]
+test = ["Aqua", "LinearAlgebra", "Measurements", "Ratios", "RecursiveArrayTools", "SaferIntegers", "SafeTestsets", "ScientificTypes", "StaticArrays", "Test", "Unitful"]

--- a/ext/DynamicQuantitiesRecursiveArrayToolsExt.jl
+++ b/ext/DynamicQuantitiesRecursiveArrayToolsExt.jl
@@ -1,0 +1,13 @@
+module DynamicQuantitiesRecursiveArrayToolsExt
+
+import DynamicQuantities: AbstractQuantity
+import RecursiveArrayTools: RecursiveArrayTools as RAT
+
+function RAT.recursive_unitless_bottom_eltype(::Type{Q}) where {T,Q<:AbstractQuantity{T}}
+    return T
+end
+function RAT.recursive_unitless_eltype(::Type{Q}) where {T,Q<:AbstractQuantity{T}}
+    return T
+end
+
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,6 +35,8 @@ Base.convert(::Type{T}, q::AbstractQuantity) where {T<:Real} =
 Base.promote_rule(::Type{Dimensions{R1}}, ::Type{Dimensions{R2}}) where {R1,R2} = Dimensions{promote_type(R1,R2)}
 Base.promote_rule(::Type{Q1}, ::Type{Q2}) where {T1,T2,D1,D2,Q1<:Quantity{T1,D1},Q2<:Quantity{T2,D2}} = Quantity{promote_type(T1,T2),promote_type(D1,D2)}
 
+Base.eltype(::Type{Q}) where {Q<:AbstractQuantity} = Q
+
 Base.keys(d::AbstractDimensions) = static_fieldnames(typeof(d))
 Base.getindex(d::AbstractDimensions, k::Symbol) = getfield(d, k)
 
@@ -96,8 +98,8 @@ Base.:(==)(::AbstractQuantity, ::WeakRef) = error("Cannot compare a quantity to 
 Base.:(==)(::WeakRef, ::AbstractQuantity) = error("Cannot compare a weakref to a quantity")
 
 
-# Simple flags:
-for f in (:iszero, :isfinite, :isinf, :isnan, :isreal)
+# Simple flags and returns:
+for f in (:iszero, :isfinite, :isinf, :isnan, :isreal, :sign)
     @eval Base.$f(q::AbstractQuantity) = $f(ustrip(q))
 end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -3,6 +3,7 @@ using DynamicQuantities: FixedRational
 using DynamicQuantities: DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
 using DynamicQuantities: array_type, value_type, dim_type, quantity_type
 using Ratios: SimpleRatio
+using RecursiveArrayTools: RecursiveArrayTools as RAT
 using SaferIntegers: SafeInt16
 using StaticArrays: SArray, MArray
 using LinearAlgebra: norm
@@ -913,5 +914,13 @@ end
         x = [1u"km/s"]
         ref = Base.RefValue(x)
         @test DynamicQuantities.materialize_first(ref) === x[1]
+    end
+end
+
+@testset "RecursiveArrayTools" begin
+    for f in (RAT.recursive_unitless_bottom_eltype, RAT.recursive_unitless_eltype)
+        @test f([0.3u"km/s"]) == Float64
+        @test f([Quantity{Float32}(0.3u"km/s")]) == Float64
+        @test f([0.3Unitful.u"km/s"]) == Float64
     end
 end


### PR DESCRIPTION
@ChrisRackauckas could you confirm this is the right behavior? I couldn't find many docs on this method unfortunately, but it seems required for downstream tools

```julia
function RecursiveArrayTools.recursive_unitless_bottom_eltype(::Type{<:AbstractQuantity{T}}) where {T}
    return T
end

function RecursiveArrayTools.recursive_unitless_eltype(::Type{<:AbstractQuantity{T}}) where {T}
    return T
end
```
