### PR TITLE
Add many other numeric methods

### DIFF
--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -12,3 +12,11 @@ Base.:*(l::AbstractDimensions, r::Number) = error("Please use an `UnionAbstractQ
 Base.:*(l::Number, r::AbstractDimensions) = error("Please use an `UnionAbstractQuantity` for multiplication. You used multiplication on types: $(typeof(l)) and $(typeof(r)).")
 Base.:/(l::AbstractDimensions, r::Number) = error("Please use an `UnionAbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
 Base.:/(l::Number, r::AbstractDimensions) = error("Please use an `UnionAbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
+
+if VERSION < v"1.7"
+    for I in (Base.MultiplicativeInverses.UnsignedMultiplicativeInverse, Base.MultiplicativeInverses.SignedMultiplicativeInverse)
+        @eval function Base.div(x::T, y::$I{T}, r::RoundingMode=RoundToZero) where {T<:AbstractGenericQuantity}
+            return new_quantity(typeof(x), div(ustrip(x), ustrip(y), r), dimension(x) / dimension(y))
+        end
+    end
+end

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -12,9 +12,3 @@ Base.:*(l::AbstractDimensions, r::Number) = error("Please use an `UnionAbstractQ
 Base.:*(l::Number, r::AbstractDimensions) = error("Please use an `UnionAbstractQuantity` for multiplication. You used multiplication on types: $(typeof(l)) and $(typeof(r)).")
 Base.:/(l::AbstractDimensions, r::Number) = error("Please use an `UnionAbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
 Base.:/(l::Number, r::AbstractDimensions) = error("Please use an `UnionAbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
-
-if VERSION < v"1.7"
-    @eval function Base.div(x::DynamicQuantities.AbstractGenericQuantity{T}, y::T) where {T}
-        return new_quantity(typeof(x), div(ustrip(x), y), dimension(x))
-    end
-end

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -16,7 +16,7 @@ Base.:/(l::Number, r::AbstractDimensions) = error("Please use an `UnionAbstractQ
 if VERSION < v"1.7"
     for I in (Base.MultiplicativeInverses.UnsignedMultiplicativeInverse, Base.MultiplicativeInverses.SignedMultiplicativeInverse)
         @eval function Base.div(x::T, y::$I{T}, r::RoundingMode=RoundToZero) where {T<:AbstractGenericQuantity}
-            return new_quantity(typeof(x), div(ustrip(x), ustrip(y), r), dimension(x) / dimension(y))
+            return new_quantity(typeof(x), div(ustrip(x), y, r), dimension(x))
         end
     end
 end

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -14,9 +14,7 @@ Base.:/(l::AbstractDimensions, r::Number) = error("Please use an `UnionAbstractQ
 Base.:/(l::Number, r::AbstractDimensions) = error("Please use an `UnionAbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
 
 if VERSION < v"1.7"
-    for I in (Base.MultiplicativeInverses.UnsignedMultiplicativeInverse, Base.MultiplicativeInverses.SignedMultiplicativeInverse)
-        @eval function Base.div(x::T, y::$I{T}, r::RoundingMode=RoundToZero) where {T<:AbstractGenericQuantity}
-            return new_quantity(typeof(x), div(ustrip(x), y, r), dimension(x))
-        end
+    @eval function Base.div(x::DynamicQuantities.AbstractGenericQuantity{T}, y::T) where {T}
+        return new_quantity(typeof(x), div(ustrip(x), y), dimension(x))
     end
 end

--- a/src/math.jl
+++ b/src/math.jl
@@ -6,11 +6,11 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
 
         Base.:*(l::$type, r::$base_type) = new_quantity(typeof(l), ustrip(l) * r, dimension(l))
         Base.:/(l::$type, r::$base_type) = new_quantity(typeof(l), ustrip(l) / r, dimension(l))
-        Base.div(x::$type, y::$base_type, r::RoundingMode=RoundToZero) = new_quantity(typeof(x), div(ustrip(x), y, r), dimension(x))
+        Base.div(x::$type, y::Number, r::RoundingMode=RoundToZero) = new_quantity(typeof(x), div(ustrip(x), y, r), dimension(x))
 
         Base.:*(l::$base_type, r::$type) = new_quantity(typeof(r), l * ustrip(r), dimension(r))
         Base.:/(l::$base_type, r::$type) = new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))
-        Base.div(x::$base_type, y::$type, r::RoundingMode=RoundToZero) = new_quantity(typeof(y), div(x, ustrip(y), r), inv(dimension(y)))
+        Base.div(x::Number, y::$type, r::RoundingMode=RoundToZero) = new_quantity(typeof(y), div(x, ustrip(y), r), inv(dimension(y)))
 
         Base.:*(l::$type, r::AbstractDimensions) = new_quantity(typeof(l), ustrip(l), dimension(l) * r)
         Base.:/(l::$type, r::AbstractDimensions) = new_quantity(typeof(l), ustrip(l), dimension(l) / r)

--- a/src/math.jl
+++ b/src/math.jl
@@ -143,7 +143,7 @@ end
 ############################## Same dimension as input ##################################
 for f in (
     :float, :abs, :real, :imag, :conj, :adjoint, :unsigned,
-    :nextfloat, :prevfloat, :identity, :transpose,
+    :nextfloat, :prevfloat, :identity, :transpose, :significand
 )
     @eval function Base.$f(q::UnionAbstractQuantity)
         return new_quantity(typeof(q), $f(ustrip(q)), dimension(q))
@@ -173,7 +173,7 @@ end
 function Base.round(::Type{Ti}, q::UnionAbstractQuantity, r::RoundingMode=RoundNearest) where {Ti<:Integer}
     return new_quantity(typeof(q), round(Ti, ustrip(q), r), dimension(q))
 end
-for f in (:floor, :trunc, :ceil, :significand)
+for f in (:floor, :trunc, :ceil)
     @eval begin
         function Base.$f(q::UnionAbstractQuantity)
             return new_quantity(typeof(q), $f(ustrip(q)), dimension(q))

--- a/src/math.jl
+++ b/src/math.jl
@@ -44,7 +44,7 @@ end
 Base.:-(l::UnionAbstractQuantity) = new_quantity(typeof(l), -ustrip(l), dimension(l))
 
 # Combining different abstract types
-for op in (:*, :/, :+, :-, :div),
+for op in (:*, :/, :+, :-, :div, :atan, :atand, :copysign, :flipsign, :mod),
     (t1, _, _) in ABSTRACT_QUANTITY_TYPES,
     (t2, _, _) in ABSTRACT_QUANTITY_TYPES
 
@@ -126,7 +126,6 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES, f in (:atan, :atand)
         end
         function Base.$f(y::$type, x::$type)
             dimension(y) == dimension(x) || throw(DimensionError(y, x))
-            y, x = promote(y, x)
             return $f(ustrip(y), ustrip(x))
         end
         function Base.$f(y::$type, x::$base_type)
@@ -143,8 +142,8 @@ end
 
 ############################## Same dimension as input ##################################
 for f in (
-    :abs, :real, :imag, :conj, :adjoint, :unsigned, :nextfloat, :prevfloat,
-    :identity, :transpose,
+    :float, :abs, :real, :imag, :conj, :adjoint, :unsigned,
+    :nextfloat, :prevfloat, :identity, :transpose,
 )
     @eval function Base.$f(q::UnionAbstractQuantity)
         return new_quantity(typeof(q), $f(ustrip(q)), dimension(q))

--- a/src/types.jl
+++ b/src/types.jl
@@ -252,4 +252,7 @@ end
 struct DimensionError{Q1,Q2} <: Exception
     q1::Q1
     q2::Q2
+
+    DimensionError(q1, q2) = new{typeof(q1),typeof(q2)}(q1, q2)
+    DimensionError(q1) = DimensionError(q1, nothing)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -106,12 +106,12 @@ function Base.isless(l::Number, r::UnionAbstractQuantity)
 end
 
 # Simple flags:
-# :iseven, :ispow2, :isfinite, :isinf, :isodd, :isinteger, :isreal,
-# :isnan, :isempty, :iszero
-for f in (:iszero, :isfinite, :isinf, :isnan, :isreal, :signbit)
+for f in (
+    :iszero, :isfinite, :isinf, :isnan, :isreal, :signbit,
+    :isempty, :iseven, :isodd, :isinteger, :ispow2
+)
     @eval Base.$f(q::UnionAbstractQuantity) = $f(ustrip(q))
 end
-Base.isempty(q::AbstractGenericQuantity) = isempty(ustrip(q))
 
 
 # Base.one, typemin, typemax

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,7 +25,6 @@ end
     return output
 end
 
-Base.float(q::UnionAbstractQuantity) = new_quantity(typeof(q), float(ustrip(q)), dimension(q))
 Base.convert(::Type{Number}, q::AbstractQuantity) = q
 function Base.convert(::Type{T}, q::UnionAbstractQuantity) where {T<:Number}
     @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -107,14 +107,13 @@ function Base.isless(l::Number, r::UnionAbstractQuantity)
 end
 
 # Simple flags:
-for f in (:iszero, :isfinite, :isinf, :isnan, :isreal)
+# :iseven, :ispow2, :isfinite, :isinf, :isodd, :isinteger, :isreal,
+# :isnan, :isempty, :iszero
+for f in (:iszero, :isfinite, :isinf, :isnan, :isreal, :signbit)
     @eval Base.$f(q::UnionAbstractQuantity) = $f(ustrip(q))
 end
+Base.isempty(q::AbstractGenericQuantity) = isempty(ustrip(q))
 
-# Simple operations which return a full quantity (same dimensions)
-for f in (:real, :imag, :conj, :adjoint, :unsigned, :nextfloat, :prevfloat)
-    @eval Base.$f(q::UnionAbstractQuantity) = new_quantity(typeof(q), $f(ustrip(q)), dimension(q))
-end
 
 # Base.one, typemin, typemax
 for f in (:one, :typemin, :typemax)
@@ -172,6 +171,7 @@ tryrationalize(::Type{R}, x::Union{Rational,Integer}) where {R} = convert(R, x)
 tryrationalize(::Type{R}, x) where {R} = isinteger(x) ? convert(R, round(Int, x)) : convert(R, rationalize(Int, x))
 
 Base.showerror(io::IO, e::DimensionError) = print(io, "DimensionError: ", e.q1, " and ", e.q2, " have incompatible dimensions")
+Base.showerror(io::IO, e::DimensionError{<:Any,Nothing}) = print(io, "DimensionError: ", e.q1, " is not dimensionless")
 
 Base.convert(::Type{Q}, q::UnionAbstractQuantity) where {Q<:UnionAbstractQuantity} = q
 Base.convert(::Type{Q}, q::UnionAbstractQuantity) where {T,Q<:UnionAbstractQuantity{T}} = new_quantity(Q, convert(T, ustrip(q)), dimension(q))

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1240,10 +1240,12 @@ end
         x = Q{Int}(10, length=1)
         y = Q{Int}(3, mass=-1)
         @test div(x, y) == Q{Int}(3, length=1, mass=1)
-        @test div(x, y, RoundFromZero) == Q{Int}(4, length=1, mass=1)
         @test div(x, 3) == Q{Int}(3, length=1)
-        @test div(x, 3, RoundFromZero) == Q{Int}(4, length=1)
         @test div(10, y) == Q{Int}(3, mass=1)
-        @test div(10, y, RoundFromZero) == Q{Int}(4, mass=1)
+        if VERSION >= v"1.9"
+            @test div(x, y, RoundFromZero) == Q{Int}(4, length=1, mass=1)
+            @test div(x, 3, RoundFromZero) == Q{Int}(4, length=1)
+            @test div(10, y, RoundFromZero) == Q{Int}(4, mass=1)
+        end
     end
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -149,6 +149,21 @@ using Test
     @test isinf(x * Inf) == true
     @test isnan(x) == false
     @test isnan(x * NaN) == true
+    @test isreal(x) == true
+    @test isreal(x * (1 + 2im)) == false
+    @test signbit(x) == true
+    @test signbit(-x) == false
+    @test isempty(x) == false
+    @test isempty(GenericQuantity([0.0, 1.0])) == false
+    @test isempty(GenericQuantity(Float64[])) == true
+    @test iseven(Quantity(2, length=1)) == true
+    @test iseven(Quantity(3, length=1)) == false
+    @test isodd(Quantity(2, length=1)) == false
+    @test isodd(Quantity(3, length=1)) == true
+    @test isinteger(Quantity(2, length=1)) == true
+    @test isinteger(Quantity(2.1, length=1)) == false
+    @test ispow2(Quantity(2, length=1)) == true
+    @test ispow2(Quantity(3, length=1)) == false
 
     @test nextfloat(x) == Quantity(nextfloat(-1.2), length=2 // 5)
     @test prevfloat(x) == Quantity(prevfloat(-1.2), length=2 // 5)

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -9,6 +9,12 @@ using StaticArrays: SArray, MArray
 using LinearAlgebra: norm
 using Test
 
+function record_show(s, f=show)
+    io = IOBuffer()
+    f(io, s)
+    return String(take!(io))
+end
+
 @testset "Basic utilities" begin
 
     for Q in [Quantity, GenericQuantity], T in [DEFAULT_VALUE_TYPE, Float16, Float32, Float64], R in [DEFAULT_DIM_BASE_TYPE, Rational{Int16}, Rational{Int32}, SimpleRatio{Int}, SimpleRatio{SafeInt16}]
@@ -447,14 +453,8 @@ end
     # Conversion to Rational without specifying type
     @test convert(Rational, FixedRational{UInt8,6}(2)) === Rational{UInt8}(2)
 
-    # Showing rationals
-    function show_string(i)
-        io = IOBuffer()
-        show(io, i)
-        return String(take!(io))
-    end
-    @test show_string(FixedRational{Int,10}(2)) == "2"
-    @test show_string(FixedRational{Int,10}(11//10)) == "11//10"
+    @test record_show(FixedRational{Int,10}(2)) == "2"
+    @test record_show(FixedRational{Int,10}(11//10)) == "11//10"
 
     # Promotion rules
     @test promote_type(FixedRational{Int64,10},FixedRational{BigInt,10}) == FixedRational{BigInt,10}
@@ -1164,6 +1164,8 @@ end
             end
         end
     end
+    s = record_show(DimensionError(u"km/s"), showerror)
+    @test occursin("not dimensionless", s)
 end
 
 @testset "Assorted dimensionful functions" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1154,6 +1154,8 @@ end
                 for y in valid_inputs[end-3:end]
                     qy_dimensionless = Quantity(y, D)
                     qy_dimensions = Quantity(y, convert(D, dimension(u"m/s")))
+                    @eval @test $f($y, $qx_dimensionless) == $f($y, $x)
+                    @eval @test $f($qy_dimensionless, $x) == $f($y, $x)
                     @eval @test $f($qy_dimensionless, $qx_dimensionless) == $f($y, $x)
                     @eval @test $f($qy_dimensions, $qx_dimensions) == $f($y, $x)
                     @eval @test_throws DimensionError $f($qy_dimensions, $x)
@@ -1170,7 +1172,7 @@ end
         :nextfloat, :prevfloat, :identity, :transpose,
         :copysign, :flipsign, :mod, :modf,
         :floor, :trunc, :ceil, :significand,
-        :ldexp, :round
+        :ldexp, :round,
     )
     for Q in (Quantity, GenericQuantity), D in (Dimensions, SymbolicDimensions), f in functions
         T = f in (:abs, :real, :imag, :conj) ? ComplexF64 : Float64
@@ -1190,6 +1192,11 @@ end
                     qx_dimensions = Q(x, dim)
                     qy_dimensions = Q(y, dim)
                     @eval @test $f($qx_dimensions, $qy_dimensions) == $Q($f($x, $y), $dim)
+                    if f in (:copysign, :flipsign, :mod)
+                        # Also do test without dimensions
+                        @eval @test $f($x, $qy_dimensions) == $f($x, $y)
+                        @eval @test $f($qx_dimensions, $y) == $Q($f($x, $y), $dim)
+                    end
                 end
             end
         elseif f == :unsigned
@@ -1198,7 +1205,7 @@ end
                 qx_dimensions = Q(x, dim)
                 @eval @test $f($qx_dimensions) == $Q($f($x), $dim)
             end
-        elseif f == :round
+        elseif f in (:round, :floor, :trunc, :ceil)
             for x in 5rand(T, 3) .- 2.5
                 dim = convert(D, dimension(u"m/s"))
                 qx_dimensions = Q(x, dim)
@@ -1225,5 +1232,18 @@ end
                 @eval @test $f($qx_dimensions) == $Q($f($x), $dim)
             end
         end
+    end
+end
+
+@testset "Test div" begin
+    for Q in (Quantity, GenericQuantity)
+        x = Q{Int}(10, length=1)
+        y = Q{Int}(3, mass=-1)
+        @test div(x, y) == Q{Int}(3, length=1, mass=1)
+        @test div(x, y, RoundFromZero) == Q{Int}(4, length=1, mass=1)
+        @test div(x, 3) == Q{Int}(3, length=1)
+        @test div(x, 3, RoundFromZero) == Q{Int}(4, length=1)
+        @test div(10, y) == Q{Int}(3, mass=1)
+        @test div(10, y, RoundFromZero) == Q{Int}(4, mass=1)
     end
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -757,6 +757,16 @@ end
     y = x ^ (3//2)
     @test y == Quantity(1.0, length=3//2)
     @test typeof(y) == Quantity{Float64,DEFAULT_DIM_TYPE}
+
+    VERSION < v"1.7" && for I in (Int64, UInt64)
+        x = GenericQuantity{I}(1u"km/s")
+        a = (
+            I <: Signed ? 
+            Base.MultiplicativeInverses.SignedMultiplicativeInverse :
+            Base.MultiplicativeInverses.UnsignedMultiplicativeInverse
+        )(I(3))
+        @test div(x, a) == GenericQuantity{I}(333u"m/s")
+    end
 end
 
 for Q in (Quantity, GenericQuantity)

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -757,16 +757,6 @@ end
     y = x ^ (3//2)
     @test y == Quantity(1.0, length=3//2)
     @test typeof(y) == Quantity{Float64,DEFAULT_DIM_TYPE}
-
-    VERSION < v"1.7" && for I in (Int64, UInt64)
-        x = GenericQuantity{I}(1u"km/s")
-        a = (
-            I <: Signed ? 
-            Base.MultiplicativeInverses.SignedMultiplicativeInverse :
-            Base.MultiplicativeInverses.UnsignedMultiplicativeInverse
-        )(I(3))
-        @test div(x, a) == GenericQuantity{I}(333u"m/s")
-    end
 end
 
 for Q in (Quantity, GenericQuantity)


### PR DESCRIPTION
This adds methods for the following functions. Most of these will throw an error if the quantity has nonzero dimensions. However some of the functions allow nonzero dimensions, and simply return an output with the same dimensions.

- `div`
- `sin`
- `cos`
- `tan`
- `sinh`
- `cosh`
- `tanh`
- `asin`
- `acos`
- `asinh`
- `acosh`
- `atanh`
- `sec`
- `csc`
- `cot`
- `asec`
- `acsc`
- `acot`
- `sech`
- `csch`
- `coth`
- `asech`
- `acsch`
- `acoth`
- `sinc`
- `cosc`
- `cosd`
- `cotd`
- `cscd`
- `secd`
- `sinpi`
- `cospi`
- `sind`
- `tand`
- `acosd`
- `acotd`
- `acscd`
- `asecd`
- `asind`
- `log`
- `log2`
- `log10`
- `log1p`
- `exp`
- `exp2`
- `exp10`
- `expm1`
- `frexp`
- `exponent`
- `atan`
- `atand`
- `adjoint`
- `unsigned`
- `identity`
- `transpose`
- `copysign`
- `flipsign`
- `mod`
- `ldexp`
- `round`
- `floor`
- `trunc`
- `ceil`
- `significand`
- `modf`
- `signbit` (in `utils.jl`)

It also moves methods over to `math.jl` for:

- `real`
- `imag`
- `conj`
- `nextfloat`
- `prevfloat`


---

TODO:

- [x] Add unittests for each