### PR TITLE
Add some `Unitful` unit names that were missing

### DIFF
--- a/src/units.jl
+++ b/src/units.jl
@@ -158,15 +158,21 @@ end
 # Common assorted units
 ## Time
 @register_unit min 60 * s
+@register_unit minute min
 @register_unit h 60 * min
 @register_unit hr h
 @register_unit day 24 * h
+@register_unit d day
+@register_unit wk 7 * day
 @register_unit yr 365.25 * day
 
 @add_prefixes min ()
+@add_prefixes minute ()
 @add_prefixes h ()
 @add_prefixes hr ()
 @add_prefixes day ()
+@add_prefixes d ()
+@add_prefixes wk ()
 @add_prefixes yr (k, M, G)
 
 ## Volume

--- a/src/units.jl
+++ b/src/units.jl
@@ -68,7 +68,7 @@ end
     kg,
 )
 @doc(
-    "Time in seconds. Available variants: `fs`, `ps`, `ns`, `μs` (/`us`), `ms`, `min`, `h` (/`hr`), `day`, `yr`, `kyr`, `Myr`, `Gyr`.",
+    "Time in seconds. Available variants: `fs`, `ps`, `ns`, `μs` (/`us`), `ms`, `min` (/`minute`), `h` (/`hr`), `day` (/`d`), `wk`, `yr`, `kyr`, `Myr`, `Gyr`.",
     s,
 )
 @doc(


### PR DESCRIPTION
There are a couple of differences between the naming of units in `Unitful` and this package that makes it not quite a direct swap when changing between the two packages. This adds a couple of aliases for current units as well as a new `wk`.

The only one that we're really needing here is `wk` since we can deal with aliasing the others internally where needed, so I'm fine with dropping those if there are reasons that they weren't included already?

---

How would you like tests written for these kinds of additions? If they are needed?