### PR TITLE
Fix promotion rules in `+, -, *, /`

### DIFF
--- a/src/math.jl
+++ b/src/math.jl
@@ -1,15 +1,15 @@
 for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
     @eval begin
         function Base.:*(l::$type, r::$type)
-            l, r = promote(l, r)
+            l, r = promote_except_value(l, r)
             new_quantity(typeof(l), ustrip(l) * ustrip(r), dimension(l) * dimension(r))
         end
         function Base.:/(l::$type, r::$type)
-            l, r = promote(l, r)
+            l, r = promote_except_value(l, r)
             new_quantity(typeof(l), ustrip(l) / ustrip(r), dimension(l) / dimension(r))
         end
         function Base.div(x::$type, y::$type, r::RoundingMode=RoundToZero)
-            x, y = promote(x, y)
+            x, y = promote_except_value(x, y)
             new_quantity(typeof(x), div(ustrip(x), ustrip(y), r), dimension(x) / dimension(y))
         end
 
@@ -57,7 +57,7 @@ Base.:/(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(-, l, r)
 for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES, op in (:+, :-)
     @eval begin
         function Base.$op(l::$type, r::$type)
-            l, r = promote(l, r)
+            l, r = promote_except_value(l, r)
             dimension(l) == dimension(r) || throw(DimensionError(l, r))
             return new_quantity(typeof(l), $op(ustrip(l), ustrip(r)), dimension(l))
         end
@@ -81,7 +81,7 @@ for op in (:*, :/, :+, :-, :div, :atan, :atand, :copysign, :flipsign, :mod),
 
     t1 == t2 && continue
 
-    @eval Base.$op(l::$t1, r::$t2) = $op(promote(l, r)...)
+    @eval Base.$op(l::$t1, r::$t2) = $op(promote_except_value(l, r)...)
 end
 
 # We don't promote on the dimension types:
@@ -156,7 +156,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES, f in (:atan, :atand)
             return $f(ustrip(x))
         end
         function Base.$f(y::$type, x::$type)
-            y, x = promote(y, x)
+            y, x = promote_except_value(y, x)
             dimension(y) == dimension(x) || throw(DimensionError(y, x))
             return $f(ustrip(y), ustrip(x))
         end
@@ -186,7 +186,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES, f in (:copysign, :flipsign,
     # and ignore any dimensions on y, since those will cancel out.
     @eval begin
         function Base.$f(x::$type, y::$type)
-            x, y = promote(x, y)
+            x, y = promote_except_value(x, y)
             return new_quantity(typeof(x), $f(ustrip(x), ustrip(y)), dimension(x))
         end
         function Base.$f(x::$type, y::$base_type)

--- a/src/math.jl
+++ b/src/math.jl
@@ -1,22 +1,52 @@
 for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
     @eval begin
-        Base.:*(l::$type, r::$type) = new_quantity(typeof(l), ustrip(l) * ustrip(r), dimension(l) * dimension(r))
-        Base.:/(l::$type, r::$type) = new_quantity(typeof(l), ustrip(l) / ustrip(r), dimension(l) / dimension(r))
-        Base.div(x::$type, y::$type, r::RoundingMode=RoundToZero) = new_quantity(typeof(x), div(ustrip(x), ustrip(y), r), dimension(x) / dimension(y))
+        function Base.:*(l::$type, r::$type)
+            l, r = promote(l, r)
+            new_quantity(typeof(l), ustrip(l) * ustrip(r), dimension(l) * dimension(r))
+        end
+        function Base.:/(l::$type, r::$type)
+            l, r = promote(l, r)
+            new_quantity(typeof(l), ustrip(l) / ustrip(r), dimension(l) / dimension(r))
+        end
+        function Base.div(x::$type, y::$type, r::RoundingMode=RoundToZero)
+            x, y = promote(x, y)
+            new_quantity(typeof(x), div(ustrip(x), ustrip(y), r), dimension(x) / dimension(y))
+        end
 
-        Base.:*(l::$type, r::$base_type) = new_quantity(typeof(l), ustrip(l) * r, dimension(l))
-        Base.:/(l::$type, r::$base_type) = new_quantity(typeof(l), ustrip(l) / r, dimension(l))
-        Base.div(x::$type, y::$base_type, r::RoundingMode=RoundToZero) = new_quantity(typeof(x), div(ustrip(x), y, r), dimension(x))
+        # The rest of the functions are unchanged because they do not operate on two variables of the custom type
+        function Base.:*(l::$type, r::$base_type)
+            new_quantity(typeof(l), ustrip(l) * r, dimension(l))
+        end
+        function Base.:/(l::$type, r::$base_type)
+            new_quantity(typeof(l), ustrip(l) / r, dimension(l))
+        end
+        function Base.div(x::$type, y::$base_type, r::RoundingMode=RoundToZero)
+            new_quantity(typeof(x), div(ustrip(x), y, r), dimension(x))
+        end
 
-        Base.:*(l::$base_type, r::$type) = new_quantity(typeof(r), l * ustrip(r), dimension(r))
-        Base.:/(l::$base_type, r::$type) = new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))
-        Base.div(x::$base_type, y::$type, r::RoundingMode=RoundToZero) = new_quantity(typeof(y), div(x, ustrip(y), r), inv(dimension(y)))
+        function Base.:*(l::$base_type, r::$type)
+            new_quantity(typeof(r), l * ustrip(r), dimension(r))
+        end
+        function Base.:/(l::$base_type, r::$type)
+            new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))
+        end
+        function Base.div(x::$base_type, y::$type, r::RoundingMode=RoundToZero)
+            new_quantity(typeof(y), div(x, ustrip(y), r), inv(dimension(y)))
+        end
 
-        Base.:*(l::$type, r::AbstractDimensions) = new_quantity(typeof(l), ustrip(l), dimension(l) * r)
-        Base.:/(l::$type, r::AbstractDimensions) = new_quantity(typeof(l), ustrip(l), dimension(l) / r)
+        function Base.:*(l::$type, r::AbstractDimensions)
+            new_quantity(typeof(l), ustrip(l), dimension(l) * r)
+        end
+        function Base.:/(l::$type, r::AbstractDimensions)
+            new_quantity(typeof(l), ustrip(l), dimension(l) / r)
+        end
 
-        Base.:*(l::AbstractDimensions, r::$type) = new_quantity(typeof(r), ustrip(r), l * dimension(r))
-        Base.:/(l::AbstractDimensions, r::$type) = new_quantity(typeof(r), inv(ustrip(r)), l / dimension(r))
+        function Base.:*(l::AbstractDimensions, r::$type)
+            new_quantity(typeof(r), ustrip(r), l * dimension(r))
+        end
+        function Base.:/(l::AbstractDimensions, r::$type)
+            new_quantity(typeof(r), inv(ustrip(r)), l / dimension(r))
+        end
     end
 end
 
@@ -27,6 +57,7 @@ Base.:/(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(-, l, r)
 for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES, op in (:+, :-)
     @eval begin
         function Base.$op(l::$type, r::$type)
+            l, r = promote(l, r)
             dimension(l) == dimension(r) || throw(DimensionError(l, r))
             return new_quantity(typeof(l), $op(ustrip(l), ustrip(r)), dimension(l))
         end
@@ -125,6 +156,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES, f in (:atan, :atand)
             return $f(ustrip(x))
         end
         function Base.$f(y::$type, x::$type)
+            y, x = promote(y, x)
             dimension(y) == dimension(x) || throw(DimensionError(y, x))
             return $f(ustrip(y), ustrip(x))
         end
@@ -154,6 +186,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES, f in (:copysign, :flipsign,
     # and ignore any dimensions on y, since those will cancel out.
     @eval begin
         function Base.$f(x::$type, y::$type)
+            x, y = promote(x, y)
             return new_quantity(typeof(x), $f(ustrip(x), ustrip(y)), dimension(x))
         end
         function Base.$f(x::$type, y::$base_type)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -77,6 +77,7 @@ Base.keys(q::UnionAbstractQuantity) = keys(ustrip(q))
 
 # Numeric checks
 function Base.isapprox(l::UnionAbstractQuantity, r::UnionAbstractQuantity; kws...)
+    l, r = promote(l, r)
     return isapprox(ustrip(l), ustrip(r); kws...) && dimension(l) == dimension(r)
 end
 function Base.isapprox(l::Number, r::UnionAbstractQuantity; kws...)
@@ -88,11 +89,15 @@ function Base.isapprox(l::UnionAbstractQuantity, r::Number; kws...)
     return isapprox(ustrip(l), r; kws...)
 end
 Base.iszero(d::AbstractDimensions) = all_dimensions(iszero, d)
-Base.:(==)(l::AbstractDimensions, r::AbstractDimensions) = all_dimensions(==, l, r)
-Base.:(==)(l::UnionAbstractQuantity, r::UnionAbstractQuantity) = ustrip(l) == ustrip(r) && dimension(l) == dimension(r)
+function Base.:(==)(l::UnionAbstractQuantity, r::UnionAbstractQuantity)
+    l, r = promote(l, r)
+    ustrip(l) == ustrip(r) && dimension(l) == dimension(r)
+end
 Base.:(==)(l::Number, r::UnionAbstractQuantity) = ustrip(l) == ustrip(r) && iszero(dimension(r))
 Base.:(==)(l::UnionAbstractQuantity, r::Number) = ustrip(l) == ustrip(r) && iszero(dimension(l))
+Base.:(==)(l::AbstractDimensions, r::AbstractDimensions) = all_dimensions(==, l, r)
 function Base.isless(l::UnionAbstractQuantity, r::UnionAbstractQuantity)
+    l, r = promote(l, r)
     dimension(l) == dimension(r) || throw(DimensionError(l, r))
     return isless(ustrip(l), ustrip(r))
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -676,7 +676,7 @@ end
         q = convert(Q{Float16}, 1.5u"g")
         qs = uconvert(convert(Q{Float16}, us"g"), 5 * q)
         @test typeof(qs) <: Q{Float16,<:SymbolicDimensions{<:Any}}
-        @test qs ≈ 7.5us"g"
+        @test isapprox(qs, 7.5us"g"; atol=0.01)
 
         # Arrays
         x = [1.0, 2.0, 3.0] .* Q(u"kg")

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -633,6 +633,16 @@ end
     qa = [x, y]
     @test qa isa Vector{Quantity{Float64,SymbolicDimensions{Rational{Int}}}}
     DynamicQuantities.with_type_parameters(SymbolicDimensions{Float64}, Rational{Int}) == SymbolicDimensions{Rational{Int}}
+
+    @testset "Promotion with Dimensions" begin
+        x = 0.5u"cm"
+        y = -0.03u"m"
+        x_s = 0.5us"cm"
+        for op in (+, -, *, /, atan, atand, copysign, flipsign, mod)
+            @test op(x, y) == op(x_s, y)
+            @test op(y, x) == op(y, x_s)
+        end
+    end
 end
 
 @testset "uconvert" begin


### PR DESCRIPTION
Right now the promotion rules for these try to promote the value type itself. This means that `Vector{Float64}` plus a `Int64` would try to promote to `Any`..... So this PR changes it so that it only promotes the quantity and dimension type, but leaves the value type to be promoted by the operation itself.

With this PR, we can now do

```julia
0.3us"km" + 0.3u"m"
```

and it will automatically convert the first term to a regular `Dimensions` before the calculation.