### PR TITLE
Fix numeric promotion rules

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -43,6 +43,30 @@ end
 function Base.promote_rule(::Type{<:Quantity{T1,D1}}, ::Type{<:Quantity{T2,D2}}) where {T1,T2,D1,D2}
     return Quantity{promote_type(T1,T2),promote_type(D1,D2)}
 end
+
+# Define promotion rules for all basic numeric types, individually.
+# We don't want to define an opinionated promotion on <:Number,
+# or even <:AbstractFloat, as it could conflict with other
+# abstract number packages which may try to do the same thing.
+# (which would lead to ambiguities)
+for (type, _, _) in ABSTRACT_QUANTITY_TYPES, numeric_type in (
+    Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32,
+    Int64, UInt64, Int128, UInt128, Float16, Float32,
+    Float64, BigFloat, BigInt, ComplexF16, ComplexF32,
+    ComplexF64, Complex{BigFloat}, Rational{Int8}, Rational{UInt8},
+    Rational{Int16}, Rational{UInt16}, Rational{Int32}, Rational{UInt32},
+    Rational{Int64}, Rational{UInt64}, Rational{Int128}, Rational{UInt128},
+    Rational{BigInt},
+)
+    @eval begin
+        function Base.promote_rule(::Type{Q}, ::Type{$numeric_type}) where {T,D,Q<:$type{T,D}}
+            return with_type_parameters(Q, promote_type(T,$numeric_type), D)
+        end
+        function Base.convert(::Type{Q}, x::$numeric_type) where {T,D,Q<:$type{T,D}}
+            return new_quantity(Q, convert(T, x), D())
+        end
+    end
+end
 function Base.promote_rule(::Type{<:AbstractQuantity}, ::Type{<:Number})
     return Number
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -49,7 +49,7 @@ end
 # or even <:AbstractFloat, as it could conflict with other
 # abstract number packages which may try to do the same thing.
 # (which would lead to ambiguities)
-for (type, _, _) in ABSTRACT_QUANTITY_TYPES, numeric_type in (
+const BASE_NUMERIC_TYPES = Union{
     Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32,
     Int64, UInt64, Int128, UInt128, Float16, Float32,
     Float64, BigFloat, BigInt, ComplexF16, ComplexF32,
@@ -57,14 +57,13 @@ for (type, _, _) in ABSTRACT_QUANTITY_TYPES, numeric_type in (
     Rational{Int16}, Rational{UInt16}, Rational{Int32}, Rational{UInt32},
     Rational{Int64}, Rational{UInt64}, Rational{Int128}, Rational{UInt128},
     Rational{BigInt},
-)
-    @eval begin
-        function Base.promote_rule(::Type{Q}, ::Type{$numeric_type}) where {T,D,Q<:$type{T,D}}
-            return with_type_parameters(Q, promote_type(T,$numeric_type), D)
-        end
-        function Base.convert(::Type{Q}, x::$numeric_type) where {T,D,Q<:$type{T,D}}
-            return new_quantity(Q, convert(T, x), D())
-        end
+}
+for (type, _, _) in ABSTRACT_QUANTITY_TYPES
+    @eval function Base.promote_rule(::Type{Q}, ::Type{T2}) where {T,D,Q<:$type{T,D},T2<:BASE_NUMERIC_TYPES}
+        return with_type_parameters(Q, promote_type(T, T2), D)
+    end
+    @eval function Base.convert(::Type{Q}, x::BASE_NUMERIC_TYPES) where {T,D,Q<:$type{T,D}}
+        return new_quantity(Q, convert(T, x), D())
     end
 end
 function Base.promote_rule(::Type{<:AbstractQuantity}, ::Type{<:Number})

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -471,6 +471,7 @@ end
     @test ar isa Vector{Number}
     @test a === ar[1]
     @test b === ar[2]
+    @test promote_type(MyNumber, typeof(a)) == Number
 
     # Explicit conversion so coverage can see it:
     D = DEFAULT_DIM_TYPE

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -452,15 +452,18 @@ end
     q2 = Quantity(2, mass=1)
     @test typeof(promote(q1, q2)) == typeof((q1, q1))
 
-    x = [0.5, 0.5u"km/s"]
-    @test x isa Vector{Number}
+    q = 0.5u"km/s"
+    x = [0.5, q]
+    @test x isa Vector{typeof(q)}
+    @test x[1] == convert(typeof(q), 0.5)
 
-    x = [0.5, GenericQuantity(0.5u"km/s")]
-    @test x isa Vector{Any}
+    q = GenericQuantity(0.5u"km/s")
+    x = [0.5, q]
+    @test x isa Vector{typeof(q)}
 
     # Explicit conversion so coverage can see it:
     D = DEFAULT_DIM_TYPE
-    @test promote_type(Quantity{Float32,D}, Float64) == Number
+    @test promote_type(Quantity{Float32,D}, Float64) == Quantity{Float64,D}
     @test promote_type(Quantity{Float32,D}, Quantity{Float64,D}) == Quantity{Float64,D}
     @test promote_type(Quantity{Float32,D}, GenericQuantity{Float64,D}) == GenericQuantity{Float64,D}
     @test promote_type(GenericQuantity{Float32,D}, GenericQuantity{Float64,D}) == GenericQuantity{Float64,D}

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -461,6 +461,17 @@ end
     x = [0.5, q]
     @test x isa Vector{typeof(q)}
 
+    # Promotion with custom numeric type:
+    @eval struct MyNumber <: Real
+        x::Float64
+    end
+    a = 0.5u"km/s"
+    b = MyNumber(0.5)
+    ar = [a, b]
+    @test ar isa Vector{Number}
+    @test a === ar[1]
+    @test b === ar[2]
+
     # Explicit conversion so coverage can see it:
     D = DEFAULT_DIM_TYPE
     @test promote_type(Quantity{Float32,D}, Float64) == Quantity{Float64,D}


### PR DESCRIPTION
@gaurav-arya this should address your comment in #78.

Now you can do 
```julia
[3.0, 1u"m"]
```
and it will be an array of `Quantity{Float64,...}`.