### PR TITLE
Add AbstractRealQuantity

### DIFF
--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -1,7 +1,7 @@
 module DynamicQuantities
 
 export Units, Constants
-export AbstractDimensions, AbstractQuantity, AbstractGenericQuantity, UnionAbstractQuantity
+export AbstractDimensions, AbstractQuantity, AbstractGenericQuantity, AbstractRealQuantity, UnionAbstractQuantity
 export Quantity, GenericQuantity, RealQuantity, Dimensions, SymbolicDimensions, QuantityArray, DimensionError
 export ustrip, dimension
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -2,7 +2,7 @@ module DynamicQuantities
 
 export Units, Constants
 export AbstractDimensions, AbstractQuantity, AbstractGenericQuantity, UnionAbstractQuantity
-export Quantity, GenericQuantity, Dimensions, SymbolicDimensions, QuantityArray, DimensionError
+export Quantity, GenericQuantity, RealQuantity, Dimensions, SymbolicDimensions, QuantityArray, DimensionError
 export ustrip, dimension
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
 export uparse, @u_str, sym_uparse, @us_str, uexpand, uconvert

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -15,7 +15,7 @@ and so can be used in most places where a normal array would be used, including 
 # Constructors
 
 - `QuantityArray(v::AbstractArray, d::AbstractDimensions)`: Create a `QuantityArray` with value `v` and dimensions `d`,
-  using `Quantity` if the eltype of `v` is numeric, and `GenericQuantity` otherwise.
+  using `RealQuantity` if the eltype of `v` is real, `Quantity` if it is numeric, and `GenericQuantity` otherwise.
 - `QuantityArray(v::AbstractArray{<:Number}, q::AbstractQuantity)`: Create a `QuantityArray` with value `v` and dimensions inferred
    with `dimension(q)`. This is so that you can easily create an array with the units module, like so:
    ```julia
@@ -52,7 +52,6 @@ struct QuantityArray{T,N,D<:AbstractDimensions,Q<:UnionAbstractQuantity{T,D},V<:
     end
 end
 
-# Construct with a Quantity (easier, as you can use the units):
 QuantityArray(v::AbstractArray; kws...) = QuantityArray(v, DEFAULT_DIM_TYPE(; kws...))
 for (type, base_type, default_type) in ABSTRACT_QUANTITY_TYPES
     @eval begin

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -15,7 +15,7 @@ and so can be used in most places where a normal array would be used, including 
 # Constructors
 
 - `QuantityArray(v::AbstractArray, d::AbstractDimensions)`: Create a `QuantityArray` with value `v` and dimensions `d`,
-  using `RealQuantity` if the eltype of `v` is real, `Quantity` if it is numeric, and `GenericQuantity` otherwise.
+  using `Quantity` if it is numeric, and `GenericQuantity` otherwise.
 - `QuantityArray(v::AbstractArray{<:Number}, q::AbstractQuantity)`: Create a `QuantityArray` with value `v` and dimensions inferred
    with `dimension(q)`. This is so that you can easily create an array with the units module, like so:
    ```julia
@@ -54,9 +54,11 @@ end
 
 QuantityArray(v::AbstractArray; kws...) = QuantityArray(v, DEFAULT_DIM_TYPE(; kws...))
 for (type, base_type, default_type) in ABSTRACT_QUANTITY_TYPES
-    @eval begin
-        QuantityArray(v::AbstractArray{<:$base_type}, q::$type) = QuantityArray(v .* ustrip(q), dimension(q), typeof(q))
-        QuantityArray(v::AbstractArray{<:$base_type}, d::AbstractDimensions) = QuantityArray(v, d, $default_type)
+    @eval QuantityArray(v::AbstractArray{<:$base_type}, q::$type) = QuantityArray(v .* ustrip(q), dimension(q), typeof(q))
+
+    # Only define defaults for Quantity and GenericQuantity. Other types, the user needs to declare explicitly.
+    if type in (AbstractQuantity, AbstractGenericQuantity)
+        @eval QuantityArray(v::AbstractArray{<:$base_type}, d::AbstractDimensions) = QuantityArray(v, d, $default_type)
     end
 end
 QuantityArray(v::QA) where {Q<:UnionAbstractQuantity,QA<:AbstractArray{Q}} =

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -15,7 +15,7 @@ and so can be used in most places where a normal array would be used, including 
 # Constructors
 
 - `QuantityArray(v::AbstractArray, d::AbstractDimensions)`: Create a `QuantityArray` with value `v` and dimensions `d`,
-  using `Quantity` if it is numeric, and `GenericQuantity` otherwise.
+  using `Quantity` if the eltype of `v` is numeric, and `GenericQuantity` otherwise.
 - `QuantityArray(v::AbstractArray{<:Number}, q::AbstractQuantity)`: Create a `QuantityArray` with value `v` and dimensions inferred
    with `dimension(q)`. This is so that you can easily create an array with the units module, like so:
    ```julia

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,7 +1,6 @@
 module Constants
 
 import ..DEFAULT_QUANTITY_TYPE
-import ..RealQuantity
 import ..Units as U
 import ..Units: _add_prefixes
 

--- a/src/constants.jl
+++ b/src/constants.jl
@@ -1,7 +1,7 @@
 module Constants
 
 import ..DEFAULT_QUANTITY_TYPE
-import ..Quantity
+import ..RealQuantity
 import ..Units as U
 import ..Units: _add_prefixes
 

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -47,6 +47,18 @@ end
 # Assorted calls found by Aqua: ################################################
 ################################################################################
 
+function Complex(q::AbstractRealQuantity)
+    @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
+    return Complex(ustrip(q))
+end
+function Complex{T}(q::AbstractRealQuantity) where {T<:Real}
+    @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
+    return Complex{T}(ustrip(q))
+end
+function Bool(q::AbstractRealQuantity)
+    @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
+    return Bool(ustrip(q))
+end
 for type in (Signed, Float64, Float32, Rational), op in (:flipsign, :copysign)
     @eval function Base.$(op)(x::$type, y::AbstractRealQuantity)
         return $(op)(x, ustrip(y))

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -52,6 +52,18 @@ for type in (Signed, Float64, Float32, Rational), op in (:flipsign, :copysign)
         return $(op)(x, ustrip(y))
     end
 end
+function Base.:*(l::Complex, r::AbstractRealQuantity)
+    new_quantity(typeof(r), l * ustrip(r), dimension(r))
+end
+function Base.:*(l::AbstractRealQuantity, r::Complex)
+    new_quantity(typeof(l), ustrip(l) * r, dimension(l))
+end
+function Base.:/(l::Complex, r::AbstractRealQuantity)
+    new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))
+end
+function Base.:/(l::AbstractRealQuantity, r::Complex)
+    new_quantity(typeof(l), ustrip(l) / r, dimension(l))
+end
 function Base.:*(l::Complex{Bool}, r::AbstractRealQuantity)
     return new_quantity(typeof(r), l * ustrip(r), dimension(r))
 end

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -49,3 +49,30 @@ for type in (Signed, Float64, Float32, Rational), op in (:flipsign, :copysign)
         return $(op)(x, ustrip(y))
     end
 end
+
+function Base.:*(l::Complex{Bool}, r::AbstractRealQuantity)
+    return new_quantity(typeof(r), l * ustrip(r), dimension(r))
+end
+function Base.:*(l::AbstractRealQuantity, r::Complex{Bool})
+    return new_quantity(typeof(l), ustrip(l) * r, dimension(l))
+end
+
+for op in (:(==), :isequal), base_type in (AbstractIrrational, AbstractFloat)
+    @eval begin
+        function Base.$(op)(l::AbstractRealQuantity, r::$base_type)
+            return $(op)(ustrip(l), r) && iszero(dimension(l))
+        end
+        function Base.$(op)(l::$base_type, r::AbstractRealQuantity)
+            return $(op)(l, ustrip(r)) && iszero(dimension(r))
+        end
+    end
+end
+
+function Base.isless(l::AbstractRealQuantity, r::AbstractFloat)
+    iszero(dimension(l)) || throw(DimensionError(l, r))
+    return isless(ustrip(l), r)
+end
+function Base.isless(l::AbstractFloat, r::AbstractRealQuantity)
+    iszero(dimension(r)) || throw(DimensionError(l, r))
+    return isless(l, ustrip(r))
+end

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -47,24 +47,12 @@ end
 # Assorted calls found by Aqua: ################################################
 ################################################################################
 
-function Complex(q::AbstractRealQuantity)
-    @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
-    return Complex(ustrip(q))
-end
-function Complex{T}(q::AbstractRealQuantity) where {T<:Real}
-    @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
-    return Complex{T}(ustrip(q))
-end
-function Bool(q::AbstractRealQuantity)
-    @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
-    return Bool(ustrip(q))
-end
 for type in (Signed, Float64, Float32, Rational), op in (:flipsign, :copysign)
     @eval function Base.$(op)(x::$type, y::AbstractRealQuantity)
         return $(op)(x, ustrip(y))
     end
 end
-for type in (Complex, Complex{Bool})
+for type in (:(Complex), :(Complex{Bool}))
     @eval begin
         function Base.:*(l::$type, r::AbstractRealQuantity)
             new_quantity(typeof(r), l * ustrip(r), dimension(r))
@@ -72,7 +60,15 @@ for type in (Complex, Complex{Bool})
         function Base.:*(l::AbstractRealQuantity, r::$type)
             new_quantity(typeof(l), ustrip(l) * r, dimension(l))
         end
+        function $type(q::AbstractRealQuantity)
+            @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
+            return $type(ustrip(q))
+        end
     end
+end
+function Bool(q::AbstractRealQuantity)
+    @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
+    return Bool(ustrip(q))
 end
 function Base.:/(l::Complex, r::AbstractRealQuantity)
     new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -1,14 +1,51 @@
-Base.isless(::AbstractQuantity, ::Missing) = missing
-Base.isless(::Missing, ::AbstractQuantity) = missing
-Base.:(==)(::AbstractQuantity, ::Missing) = missing
-Base.:(==)(::Missing, ::AbstractQuantity) = missing
-Base.isapprox(::AbstractQuantity, ::Missing; kws...) = missing
-Base.isapprox(::Missing, ::AbstractQuantity; kws...) = missing
+for op in (:isless, :(==), :isequal, :(<)), (type, _, _) in ABSTRACT_QUANTITY_TYPES
+    @eval begin
+        Base.$(op)(::$type, ::Missing) = missing
+        Base.$(op)(::Missing, ::$type) = missing
+    end
+end
+for op in (:isapprox,), (type, _, _) in ABSTRACT_QUANTITY_TYPES
+    @eval begin
+        Base.$(op)(::$type, ::Missing; kws...) = missing
+        Base.$(op)(::Missing, ::$type; kws...) = missing
+    end
+end
 
-Base.:(==)(::AbstractQuantity, ::WeakRef) = error("Cannot compare a quantity to a weakref")
-Base.:(==)(::WeakRef, ::AbstractQuantity) = error("Cannot compare a weakref to a quantity")
+for (type, _, _) in ABSTRACT_QUANTITY_TYPES
+    @eval begin
+        Base.:(==)(::$type, ::WeakRef) = error("Cannot compare a quantity to a weakref")
+        Base.:(==)(::WeakRef, ::$type) = error("Cannot compare a weakref to a quantity")
+    end
+end
 
 Base.:*(l::AbstractDimensions, r::Number) = error("Please use an `UnionAbstractQuantity` for multiplication. You used multiplication on types: $(typeof(l)) and $(typeof(r)).")
 Base.:*(l::Number, r::AbstractDimensions) = error("Please use an `UnionAbstractQuantity` for multiplication. You used multiplication on types: $(typeof(l)) and $(typeof(r)).")
 Base.:/(l::AbstractDimensions, r::Number) = error("Please use an `UnionAbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
 Base.:/(l::Number, r::AbstractDimensions) = error("Please use an `UnionAbstractQuantity` for division. You used division on types: $(typeof(l)) and $(typeof(r)).")
+
+# Promotion ambiguities
+function Base.promote_rule(::Type{F}, ::Type{Bool}) where {F<:FixedRational}
+    return F
+end
+function Base.promote_rule(::Type{Bool}, ::Type{F}) where {F<:FixedRational}
+    return F
+end
+function Base.promote_rule(::Type{F}, ::Type{BigFloat}) where {F<:FixedRational}
+    return promote_type(Rational{num_type(F)}, BigFloat)
+end
+function Base.promote_rule(::Type{BigFloat}, ::Type{F}) where {F<:FixedRational}
+    return promote_type(Rational{num_type(F)}, BigFloat)
+end
+function Base.promote_rule(::Type{F}, ::Type{T}) where {F<:FixedRational,T<:AbstractIrrational}
+    return promote_type(Rational{num_type(F)}, T)
+end
+function Base.promote_rule(::Type{T}, ::Type{F}) where {F<:FixedRational,T<:AbstractIrrational}
+    return promote_type(Rational{num_type(F)}, T)
+end
+
+# Assorted calls found by Aqua:
+for type in (Signed, Float64, Float32, Rational), op in (:flipsign, :copysign)
+    @eval function Base.$(op)(x::$type, y::AbstractRealQuantity)
+        return $(op)(x, ustrip(y))
+    end
+end

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -31,16 +31,16 @@ function Base.promote_rule(::Type{Bool}, ::Type{F}) where {F<:FixedRational}
     return F
 end
 function Base.promote_rule(::Type{F}, ::Type{BigFloat}) where {F<:FixedRational}
-    return promote_type(Rational{num_type(F)}, BigFloat)
+    return promote_type(Rational{eltype(F)}, BigFloat)
 end
 function Base.promote_rule(::Type{BigFloat}, ::Type{F}) where {F<:FixedRational}
-    return promote_type(Rational{num_type(F)}, BigFloat)
+    return promote_type(Rational{eltype(F)}, BigFloat)
 end
 function Base.promote_rule(::Type{F}, ::Type{T}) where {F<:FixedRational,T<:AbstractIrrational}
-    return promote_type(Rational{num_type(F)}, T)
+    return promote_type(Rational{eltype(F)}, T)
 end
 function Base.promote_rule(::Type{T}, ::Type{F}) where {F<:FixedRational,T<:AbstractIrrational}
-    return promote_type(Rational{num_type(F)}, T)
+    return promote_type(Rational{eltype(F)}, T)
 end
 
 # Assorted calls found by Aqua:

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -64,23 +64,21 @@ for type in (Signed, Float64, Float32, Rational), op in (:flipsign, :copysign)
         return $(op)(x, ustrip(y))
     end
 end
-function Base.:*(l::Complex, r::AbstractRealQuantity)
-    new_quantity(typeof(r), l * ustrip(r), dimension(r))
-end
-function Base.:*(l::AbstractRealQuantity, r::Complex)
-    new_quantity(typeof(l), ustrip(l) * r, dimension(l))
+for type in (Complex, Complex{Bool})
+    @eval begin
+        function Base.:*(l::$type, r::AbstractRealQuantity)
+            new_quantity(typeof(r), l * ustrip(r), dimension(r))
+        end
+        function Base.:*(l::AbstractRealQuantity, r::$type)
+            new_quantity(typeof(l), ustrip(l) * r, dimension(l))
+        end
+    end
 end
 function Base.:/(l::Complex, r::AbstractRealQuantity)
     new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))
 end
 function Base.:/(l::AbstractRealQuantity, r::Complex)
     new_quantity(typeof(l), ustrip(l) / r, dimension(l))
-end
-function Base.:*(l::Complex{Bool}, r::AbstractRealQuantity)
-    return new_quantity(typeof(r), l * ustrip(r), dimension(r))
-end
-function Base.:*(l::AbstractRealQuantity, r::Complex{Bool})
-    return new_quantity(typeof(l), ustrip(l) * r, dimension(l))
 end
 for op in (:(==), :isequal), base_type in (AbstractIrrational, AbstractFloat)
     @eval begin

--- a/src/disambiguities.jl
+++ b/src/disambiguities.jl
@@ -60,15 +60,17 @@ for type in (:(Complex), :(Complex{Bool}))
         function Base.:*(l::AbstractRealQuantity, r::$type)
             new_quantity(typeof(l), ustrip(l) * r, dimension(l))
         end
-        function $type(q::AbstractRealQuantity)
-            @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
-            return $type(ustrip(q))
-        end
     end
 end
-function Bool(q::AbstractRealQuantity)
+function Complex{T}(q::AbstractRealQuantity) where {T<:Real}
     @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
-    return Bool(ustrip(q))
+    return Complex{T}(ustrip(q))
+end
+for type in (:Bool, :Complex)
+    @eval function $type(q::AbstractRealQuantity)
+        @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
+        return $type(ustrip(q))
+    end
 end
 function Base.:/(l::Complex, r::AbstractRealQuantity)
     new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -29,26 +29,25 @@ denom(x::FixedRational) = denom(typeof(x))
 # Otherwise, we would have type instability.
 val_denom(::Type{<:F}) where {F<:FixedRational} = Val(_denom(F))
 
-num_type(::Type{<:FixedRational{T}}) where {T} = T
-num_type(x::FixedRational) = num_type(typeof(x))
+Base.eltype(::Type{<:FixedRational{T}}) where {T} = T
 
 const DEFAULT_NUMERATOR_TYPE = Int32
 const DEFAULT_DENOM = DEFAULT_NUMERATOR_TYPE(2^4 * 3^2 * 5^2 * 7)
 
 (::Type{F})(x::F) where {F<:FixedRational} = x
-(::Type{F})(x::F2) where {T,T2,den,F<:FixedRational{T,den},F2<:FixedRational{T2,den}} = unsafe_fixed_rational(x.num, num_type(F), val_denom(F))
-(::Type{F})(x::Integer) where {F<:FixedRational} = unsafe_fixed_rational(x * denom(F), num_type(F), val_denom(F))
-(::Type{F})(x::Rational) where {F<:FixedRational} = unsafe_fixed_rational(widemul(x.num, denom(F)) ÷ x.den, num_type(F), val_denom(F))
+(::Type{F})(x::F2) where {T,T2,den,F<:FixedRational{T,den},F2<:FixedRational{T2,den}} = unsafe_fixed_rational(x.num, eltype(F), val_denom(F))
+(::Type{F})(x::Integer) where {F<:FixedRational} = unsafe_fixed_rational(x * denom(F), eltype(F), val_denom(F))
+(::Type{F})(x::Rational) where {F<:FixedRational} = unsafe_fixed_rational(widemul(x.num, denom(F)) ÷ x.den, eltype(F), val_denom(F))
 
-Base.:*(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(widemul(l.num, r.num) ÷ denom(F), num_type(F), val_denom(F))
-Base.:+(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l.num + r.num, num_type(F), val_denom(F))
-Base.:-(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l.num - r.num, num_type(F), val_denom(F))
-Base.:-(x::F) where {F<:FixedRational} = unsafe_fixed_rational(-x.num, num_type(F), val_denom(F))
+Base.:*(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(widemul(l.num, r.num) ÷ denom(F), eltype(F), val_denom(F))
+Base.:+(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l.num + r.num, eltype(F), val_denom(F))
+Base.:-(l::F, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l.num - r.num, eltype(F), val_denom(F))
+Base.:-(x::F) where {F<:FixedRational} = unsafe_fixed_rational(-x.num, eltype(F), val_denom(F))
 
-Base.inv(x::F) where {F<:FixedRational} = unsafe_fixed_rational(widemul(denom(F), denom(F)) ÷ x.num, num_type(F), val_denom(F))
+Base.inv(x::F) where {F<:FixedRational} = unsafe_fixed_rational(widemul(denom(F), denom(F)) ÷ x.num, eltype(F), val_denom(F))
 
-Base.:*(l::F, r::Integer) where {F<:FixedRational} = unsafe_fixed_rational(l.num * r, num_type(F), val_denom(F))
-Base.:*(l::Integer, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l * r.num, num_type(F), val_denom(F))
+Base.:*(l::F, r::Integer) where {F<:FixedRational} = unsafe_fixed_rational(l.num * r, eltype(F), val_denom(F))
+Base.:*(l::Integer, r::F) where {F<:FixedRational} = unsafe_fixed_rational(l * r.num, eltype(F), val_denom(F))
 
 for comp in (:(==), :isequal, :<, :(isless), :<=)
     @eval Base.$comp(x::F, y::F) where {F<:FixedRational} = $comp(x.num, y.num)
@@ -59,7 +58,7 @@ Base.isone(x::F) where {F<:FixedRational} = x.num == denom(F)
 Base.isinteger(x::F) where {F<:FixedRational} = iszero(x.num % denom(F))
 
 Rational{R}(x::F) where {R,F<:FixedRational} = Rational{R}(x.num, denom(F))
-Rational(x::F) where {F<:FixedRational} = Rational{num_type(F)}(x)
+Rational(x::F) where {F<:FixedRational} = Rational{eltype(F)}(x)
 (::Type{AF})(x::F) where {AF<:AbstractFloat,F<:FixedRational} = convert(AF, x.num) / convert(AF, denom(F))
 (::Type{I})(x::F) where {I<:Integer,F<:FixedRational} =
     let
@@ -79,13 +78,13 @@ Base.decompose(x::F) where {T,F<:FixedRational{T}} = (x.num, zero(T), denom(F))
 function Base.promote_rule(::Type{F1}, ::Type{F2}) where {F1<:FixedRational,F2<:FixedRational}
     _denom(F1) == _denom(F2) ||
         error("Refusing to promote `FixedRational` types with mixed denominators. Use `Rational` instead.")
-    return FixedRational{promote_type(num_type(F1), num_type(F2)), _denom(F1)}
+    return FixedRational{promote_type(eltype(F1), eltype(F2)), _denom(F1)}
 end
 function Base.promote_rule(::Type{F}, ::Type{Rational{T2}}) where {F<:FixedRational,T2}
-    return Rational{promote_type(num_type(F),T2)}
+    return Rational{promote_type(eltype(F),T2)}
 end
 function Base.promote_rule(::Type{Rational{T2}}, ::Type{F}) where {F<:FixedRational,T2}
-    return Rational{promote_type(num_type(F),T2)}
+    return Rational{promote_type(eltype(F),T2)}
 end
 
 # We want to consume integers
@@ -98,15 +97,15 @@ end
 
 # Promotion with general types promotes like a rational
 function Base.promote_rule(::Type{T}, ::Type{T2}) where {T2<:Real,T<:FixedRational}
-    return promote_type(Rational{num_type(T)}, T2)
+    return promote_type(Rational{eltype(T)}, T2)
 end
 function Base.promote_rule(::Type{T2}, ::Type{T}) where {T2<:Real,T<:FixedRational}
-    return promote_type(Rational{num_type(T)}, T2)
+    return promote_type(Rational{eltype(T)}, T2)
 end
 
 Base.string(x::FixedRational) =
     let
-        isinteger(x) && return string(convert(num_type(x), x))
+        isinteger(x) && return string(convert(eltype(x), x))
         g = gcd(x.num, denom(x))
         return string(div(x.num, g)) * "//" * string(div(denom(x), g))
     end
@@ -114,7 +113,7 @@ Base.show(io::IO, x::FixedRational) = print(io, string(x))
 
 tryrationalize(::Type{F}, x::F) where {F<:FixedRational} = x
 tryrationalize(::Type{F}, x::Union{Rational,Integer}) where {F<:FixedRational} = convert(F, x)
-tryrationalize(::Type{F}, x) where {F<:FixedRational} = unsafe_fixed_rational(round(num_type(F), x * denom(F)), num_type(F), val_denom(F))
+tryrationalize(::Type{F}, x) where {F<:FixedRational} = unsafe_fixed_rational(round(eltype(F), x * denom(F)), eltype(F), val_denom(F))
 
 # Fix method ambiguities
 Base.round(::Type{T}, x::F, r::RoundingMode=RoundNearest) where {T>:Missing, F<:FixedRational} = round(Base.nonmissingtype_checked(T), x, r)

--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -83,11 +83,20 @@ end
 function Base.promote_rule(::Type{<:FixedRational{T1}}, ::Type{Rational{T2}}) where {T1,T2}
     return Rational{promote_type(T1,T2)}
 end
+function Base.promote_rule(::Type{Rational{T2}}, ::Type{<:FixedRational{T1}}) where {T1,T2}
+    return Rational{promote_type(T1,T2)}
+end
 function Base.promote_rule(::Type{<:FixedRational{T1}}, ::Type{T2}) where {T1,T2<:Real}
     return promote_type(Rational{T1}, T2)
 end
+function Base.promote_rule(::Type{T2}, ::Type{<:FixedRational{T1}}) where {T1,T2<:Real}
+    return promote_type(Rational{T1}, T2)
+end
+# Want to consume integers:
 function Base.promote_rule(::Type{F}, ::Type{<:Integer}) where {F<:FixedRational}
-    # Want to consume integers:
+    return F
+end
+function Base.promote_rule(::Type{<:Integer}, ::Type{F}) where {F<:FixedRational}
     return F
 end
 

--- a/src/math.jl
+++ b/src/math.jl
@@ -20,7 +20,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
         function Base.:/(l::$type, r::$base_type)
             new_quantity(typeof(l), ustrip(l) / r, dimension(l))
         end
-        function Base.div(x::$type, y::Number, r::RoundingMode=RoundToZero)
+        function Base.div(x::$type, y::$base_type, r::RoundingMode=RoundToZero)
             new_quantity(typeof(x), div(ustrip(x), y, r), dimension(x))
         end
 
@@ -30,7 +30,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
         function Base.:/(l::$base_type, r::$type)
             new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))
         end
-        function Base.div(x::Number, y::$type, r::RoundingMode=RoundToZero)
+        function Base.div(x::$base_type, y::$type, r::RoundingMode=RoundToZero)
             new_quantity(typeof(y), div(x, ustrip(y), r), inv(dimension(y)))
         end
 
@@ -75,13 +75,20 @@ end
 Base.:-(l::UnionAbstractQuantity) = new_quantity(typeof(l), -ustrip(l), dimension(l))
 
 # Combining different abstract types
-for op in (:*, :/, :+, :-, :div, :atan, :atand, :copysign, :flipsign, :mod),
+for op in (:*, :/, :+, :-, :atan, :atand, :copysign, :flipsign, :mod),
     (t1, _, _) in ABSTRACT_QUANTITY_TYPES,
     (t2, _, _) in ABSTRACT_QUANTITY_TYPES
 
     t1 == t2 && continue
 
     @eval Base.$op(l::$t1, r::$t2) = $op(promote_except_value(l, r)...)
+end
+# different methods needed:
+for (t1, _, _) in ABSTRACT_QUANTITY_TYPES, (t2, _, _) in ABSTRACT_QUANTITY_TYPES
+
+    t1 == t2 && continue
+
+    @eval Base.div(x::$t1, y::$t2, r::RoundingMode=RoundToZero) = div(promote_except_value(x, y)..., r)
 end
 
 # We don't promote on the dimension types:

--- a/src/math.jl
+++ b/src/math.jl
@@ -50,6 +50,24 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
     end
 end
 
+# Complex multiplication
+for (type, _, _) in ABSTRACT_QUANTITY_TYPES
+    @eval begin
+        function Base.:*(l::Complex, r::$type)
+            new_quantity(typeof(r), l * ustrip(r), dimension(r))
+        end
+        function Base.:*(l::$type, r::Complex)
+            new_quantity(typeof(l), ustrip(l) * r, dimension(l))
+        end
+        function Base.:/(l::Complex, r::$type)
+            new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))
+        end
+        function Base.:/(l::$type, r::Complex)
+            new_quantity(typeof(r), ustrip(l) / r, dimension(r))
+        end
+    end
+end
+
 Base.:*(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(+, l, r)
 Base.:/(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(-, l, r)
 
@@ -125,6 +143,10 @@ for (type, _, _) in ABSTRACT_QUANTITY_TYPES
         Base.:^(l::$type, r::Integer) = _pow_int(l, r)
         Base.:^(l::$type, r::Number) = _pow(l, r)
         Base.:^(l::$type, r::Rational) = _pow(l, r)
+        function Base.:^(l::$type, r::Complex)
+            iszero(dimension(l)) || throw(DimensionError(l))
+            return new_quantity(typeof(l), ustrip(l)^r, dimension(l))
+        end
     end
 end
 @inline Base.literal_pow(::typeof(^), l::AbstractDimensions, ::Val{p}) where {p} = map_dimensions(Base.Fix1(*, p), l)

--- a/src/math.jl
+++ b/src/math.jl
@@ -1,5 +1,5 @@
 for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
-    div_base_type = type == AbstractGenericQuantity ? Number : base_type
+    div_base_type = type === AbstractGenericQuantity ? Number : base_type
     @eval begin
         function Base.:*(l::$type, r::$type)
             l, r = promote_except_value(l, r)

--- a/src/math.jl
+++ b/src/math.jl
@@ -1,4 +1,5 @@
 for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
+    div_base_type = type == AbstractGenericQuantity ? Number : base_type
     @eval begin
         function Base.:*(l::$type, r::$type)
             l, r = promote_except_value(l, r)
@@ -20,7 +21,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
         function Base.:/(l::$type, r::$base_type)
             new_quantity(typeof(l), ustrip(l) / r, dimension(l))
         end
-        function Base.div(x::$type, y::$base_type, r::RoundingMode=RoundToZero)
+        function Base.div(x::$type, y::$div_base_type, r::RoundingMode=RoundToZero)
             new_quantity(typeof(x), div(ustrip(x), y, r), dimension(x))
         end
 
@@ -30,7 +31,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
         function Base.:/(l::$base_type, r::$type)
             new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))
         end
-        function Base.div(x::$base_type, y::$type, r::RoundingMode=RoundToZero)
+        function Base.div(x::$div_base_type, y::$type, r::RoundingMode=RoundToZero)
             new_quantity(typeof(y), div(x, ustrip(y), r), inv(dimension(y)))
         end
 

--- a/src/math.jl
+++ b/src/math.jl
@@ -51,24 +51,6 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
     end
 end
 
-# Complex multiplication
-for (type, _, _) in ABSTRACT_QUANTITY_TYPES
-    @eval begin
-        function Base.:*(l::Complex, r::$type)
-            new_quantity(typeof(r), l * ustrip(r), dimension(r))
-        end
-        function Base.:*(l::$type, r::Complex)
-            new_quantity(typeof(l), ustrip(l) * r, dimension(l))
-        end
-        function Base.:/(l::Complex, r::$type)
-            new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))
-        end
-        function Base.:/(l::$type, r::Complex)
-            new_quantity(typeof(l), ustrip(l) / r, dimension(l))
-        end
-    end
-end
-
 Base.:*(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(+, l, r)
 Base.:/(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(-, l, r)
 

--- a/src/math.jl
+++ b/src/math.jl
@@ -64,7 +64,7 @@ for (type, _, _) in ABSTRACT_QUANTITY_TYPES
             new_quantity(typeof(r), l / ustrip(r), inv(dimension(r)))
         end
         function Base.:/(l::$type, r::Complex)
-            new_quantity(typeof(r), ustrip(l) / r, dimension(r))
+            new_quantity(typeof(l), ustrip(l) / r, dimension(l))
         end
     end
 end

--- a/src/math.jl
+++ b/src/math.jl
@@ -204,7 +204,7 @@ end
 ############################## Same dimension as input ##################################
 for f in (
     :float, :abs, :real, :imag, :conj, :adjoint, :unsigned,
-    :nextfloat, :prevfloat, :identity, :transpose, :significand
+    :nextfloat, :prevfloat, :transpose, :significand
 )
     @eval function Base.$f(q::UnionAbstractQuantity)
         return new_quantity(typeof(q), $f(ustrip(q)), dimension(q))

--- a/src/math.jl
+++ b/src/math.jl
@@ -55,7 +55,7 @@ end
 Base.:*(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(+, l, r)
 Base.:/(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(-, l, r)
 
-# Defines + and -
+# Defines +, -, and mod
 for (type, true_base_type, _) in ABSTRACT_QUANTITY_TYPES, op in (:+, :-, :mod)
     # Only define `mod` on `Number` types:
     base_type = (op == :mod && !(true_base_type <: Number)) ? Number : true_base_type

--- a/src/math.jl
+++ b/src/math.jl
@@ -50,15 +50,6 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
             new_quantity(typeof(r), inv(ustrip(r)), l / dimension(r))
         end
     end
-    # Comparison with exact value type, in case we had to artificially limit it to Number
-    !(base_type <: Number) && @eval begin
-        function Base.div(x::$type{T}, y::T, r::RoundingMode=RoundToZero) where {T<:$base_type}
-            new_quantity(typeof(x), div(ustrip(x), y, r), dimension(x))
-        end
-        function Base.div(x::T, y::$type{T}, r::RoundingMode=RoundToZero) where {T<:$base_type}
-            new_quantity(typeof(y), div(x, ustrip(y), r), inv(dimension(y)))
-        end
-    end
 end
 
 Base.:*(l::AbstractDimensions, r::AbstractDimensions) = map_dimensions(+, l, r)
@@ -216,7 +207,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES, f in (:copysign, :flipsign,
         end
     end
 end
-# Define :rem
+# Define :rem (unfortunately we have to create a method for each rounding mode to avoid ambiguity)
 for (type, true_base_type, _) in ABSTRACT_QUANTITY_TYPES, rounding_mode in (RoundingMode, RoundingMode{:ToZero}, RoundingMode{:Down}, RoundingMode{:Up}, RoundingMode{:FromZero})
 
     # We don't want to go more generic than `Number` for mod and rem

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -104,9 +104,9 @@ end
     uexpand(q::UnionAbstractQuantity{<:Any,<:SymbolicDimensions})
 
 Expand the symbolic units in a quantity to their base SI form.
-In other words, this converts a `Quantity` with `SymbolicDimensions`
+In other words, this converts a quantity with `SymbolicDimensions`
 to one with `Dimensions`. The opposite of this function is `uconvert`,
-for converting to specific symbolic units, or `convert(Quantity{<:Any,<:SymbolicDimensions}, q)`,
+for converting to specific symbolic units, or, e.g., `convert(Quantity{<:Any,<:SymbolicDimensions}, q)`,
 for assuming SI units as the output symbols.
 """
 function uexpand(q::Q) where {T,R,D<:SymbolicDimensions{R},Q<:UnionAbstractQuantity{T,D}}
@@ -277,7 +277,7 @@ module SymbolicUnitsParse
     import ..SYMBOL_CONFLICTS
     import ..SymbolicDimensions
 
-    import ...Quantity
+    import ...RealQuantity
     import ...DEFAULT_VALUE_TYPE
     import ...DEFAULT_DIM_BASE_TYPE
 
@@ -287,7 +287,7 @@ module SymbolicUnitsParse
         import ..SYMBOL_CONFLICTS
         import ..SymbolicDimensions
 
-        import ..Quantity
+        import ..RealQuantity
         import ..DEFAULT_VALUE_TYPE
         import ..DEFAULT_DIM_BASE_TYPE
 
@@ -299,11 +299,11 @@ module SymbolicUnitsParse
             CONSTANT_SYMBOLS_EXIST[] || lock(CONSTANT_SYMBOLS_LOCK) do
                 CONSTANT_SYMBOLS_EXIST[] && return nothing
                 for unit in setdiff(CONSTANT_SYMBOLS, SYMBOL_CONFLICTS)
-                    @eval const $unit = Quantity(DEFAULT_VALUE_TYPE(1.0), SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}; $(unit)=1)
+                    @eval const $unit = RealQuantity(DEFAULT_VALUE_TYPE(1.0), SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}; $(unit)=1)
                 end
                 # Evaluate conflicting symbols to non-symbolic form:
                 for unit in SYMBOL_CONFLICTS
-                    @eval const $unit = convert(Quantity{DEFAULT_VALUE_TYPE,SymbolicDimensions}, EagerConstants.$unit)
+                    @eval const $unit = convert(RealQuantity{DEFAULT_VALUE_TYPE,SymbolicDimensions}, EagerConstants.$unit)
                 end
                 CONSTANT_SYMBOLS_EXIST[] = true
             end
@@ -318,7 +318,7 @@ module SymbolicUnitsParse
         UNIT_SYMBOLS_EXIST[] || lock(UNIT_SYMBOLS_LOCK) do
             UNIT_SYMBOLS_EXIST[] && return nothing
             for unit in UNIT_SYMBOLS
-                @eval const $unit = Quantity(DEFAULT_VALUE_TYPE(1.0), SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}; $(unit)=1)
+                @eval const $unit = RealQuantity(DEFAULT_VALUE_TYPE(1.0), SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}; $(unit)=1)
             end
             UNIT_SYMBOLS_EXIST[] = true
         end
@@ -329,27 +329,27 @@ module SymbolicUnitsParse
         sym_uparse(raw_string::AbstractString)
 
     Parse a string containing an expression of units and return the
-    corresponding `Quantity` object with `Float64` value.
+    corresponding `RealQuantity` object with `Float64` value.
     However, that unlike the regular `u"..."` macro, this macro uses
     `SymbolicDimensions` for the dimension type, which means that all units and
     constants are stored symbolically and will not automatically expand to SI
     units. For example, `sym_uparse("km/s^2")` would be parsed to
-    `Quantity(1.0, SymbolicDimensions, km=1, s=-2)`.
+    `RealQuantity(1.0, SymbolicDimensions, km=1, s=-2)`.
 
     Note that inside this expression, you also have access to the `Constants`
     module. So, for example, `sym_uparse("Constants.c^2 * Hz^2")` would evaluate to
-    `Quantity(1.0, SymbolicDimensions, c=2, Hz=2)`. However, note that due to
+    `RealQuantity(1.0, SymbolicDimensions, c=2, Hz=2)`. However, note that due to
     namespace collisions, a few physical constants are automatically converted.
     """
     function sym_uparse(raw_string::AbstractString)
         _generate_unit_symbols()
         Constants._generate_unit_symbols()
         raw_result = eval(Meta.parse(raw_string))
-        return copy(as_quantity(raw_result))::Quantity{DEFAULT_VALUE_TYPE,SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}}
+        return copy(as_quantity(raw_result))::RealQuantity{DEFAULT_VALUE_TYPE,SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}}
     end
 
-    as_quantity(q::Quantity) = q
-    as_quantity(x::Number) = Quantity(convert(DEFAULT_VALUE_TYPE, x), SymbolicDimensions{DEFAULT_DIM_BASE_TYPE})
+    as_quantity(q::RealQuantity) = q
+    as_quantity(x::Number) = RealQuantity(convert(DEFAULT_VALUE_TYPE, x), SymbolicDimensions{DEFAULT_DIM_BASE_TYPE})
     as_quantity(x) = error("Unexpected type evaluated: $(typeof(x))")
 end
 
@@ -359,15 +359,15 @@ import .SymbolicUnitsParse: sym_uparse
     us"[unit expression]"
 
 Parse a string containing an expression of units and return the
-corresponding `Quantity` object with `Float64` value. However,
+corresponding `RealQuantity` object with `Float64` value. However,
 unlike the regular `u"..."` macro, this macro uses `SymbolicDimensions`
 for the dimension type, which means that all units and constants
 are stored symbolically and will not automatically expand to SI units.
-For example, `us"km/s^2"` would be parsed to `Quantity(1.0, SymbolicDimensions, km=1, s=-2)`.
+For example, `us"km/s^2"` would be parsed to `RealQuantity(1.0, SymbolicDimensions, km=1, s=-2)`.
 
 Note that inside this expression, you also have access to the `Constants`
 module. So, for example, `us"Constants.c^2 * Hz^2"` would evaluate to
-`Quantity(1.0, SymbolicDimensions, c=2, Hz=2)`. However, note that due to
+`RealQuantity(1.0, SymbolicDimensions, c=2, Hz=2)`. However, note that due to
 namespace collisions, a few physical constants are automatically converted.
 """
 macro us_str(s)
@@ -378,5 +378,8 @@ function Base.promote_rule(::Type{SymbolicDimensions{R1}}, ::Type{SymbolicDimens
     return SymbolicDimensions{promote_type(R1,R2)}
 end
 function Base.promote_rule(::Type{SymbolicDimensions{R1}}, ::Type{Dimensions{R2}}) where {R1,R2}
+    return Dimensions{promote_type(R1,R2)}
+end
+function Base.promote_rule(::Type{Dimensions{R2}}, ::Type{SymbolicDimensions{R1}}) where {R1,R2}
     return Dimensions{promote_type(R1,R2)}
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -191,7 +191,11 @@ A constant tuple of the existing abstract quantity types,
 each as a tuple with (1) the abstract type,
 (2) the base type, and (3) the default exported concrete type.
 """
-const ABSTRACT_QUANTITY_TYPES = ((AbstractQuantity, Number, Quantity), (AbstractGenericQuantity, Any, GenericQuantity), (AbstractRealQuantity, Real, RealQuantity))
+const ABSTRACT_QUANTITY_TYPES = (
+    (AbstractQuantity, Number, Quantity),
+    (AbstractGenericQuantity, Any, GenericQuantity),
+    (AbstractRealQuantity, Real, RealQuantity)
+)
 
 """
     promote_quantity(::Type{<:UnionAbstractQuantity}, t::Type{<:Any})
@@ -202,7 +206,7 @@ If the current quantity type can already accommodate `t`, then the current type 
 promote_quantity(::Type{<:Union{GenericQuantity,Quantity,RealQuantity}}, ::Type{<:Any}) = GenericQuantity
 promote_quantity(::Type{<:Union{Quantity,RealQuantity}}, ::Type{<:Number}) = Quantity
 promote_quantity(::Type{<:RealQuantity}, ::Type{<:Real}) = RealQuantity
-promote_quantity(T, _) = t
+promote_quantity(T, _) = T
 
 for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
     @eval begin
@@ -222,8 +226,13 @@ end
 
 const DEFAULT_QUANTITY_TYPE = RealQuantity{DEFAULT_VALUE_TYPE, DEFAULT_DIM_TYPE}
 
-new_dimensions(::Type{D}, dims...) where {D<:AbstractDimensions} = constructorof(D)(dims...)
-new_quantity(::Type{Q}, l, r) where {Q<:UnionAbstractQuantity} = constructorof(Q)(l, r)
+@inline function new_dimensions(::Type{D}, dims...) where {D<:AbstractDimensions}
+    return constructorof(D)(dims...)
+end
+@inline function new_quantity(::Type{Q}, val, dims) where {Q<:UnionAbstractQuantity}
+    Qout = promote_quantity(Q, typeof(val))
+    return constructorof(Qout)(val, dims)
+end
 
 dim_type(::Type{Q}) where {T,D<:AbstractDimensions,Q<:UnionAbstractQuantity{T,D}} = D
 dim_type(::Type{<:UnionAbstractQuantity}) = DEFAULT_DIM_TYPE

--- a/src/types.jl
+++ b/src/types.jl
@@ -57,6 +57,14 @@ _as well as any other future abstract quantity types_,
 abstract type AbstractGenericQuantity{T,D} end
 
 """
+    AbstractRealQuantity{T,D} <: Real
+
+This has the same behavior as `AbstractQuantity` but is subtyped to `Real` rather
+than `Number`.
+"""
+abstract type AbstractRealQuantity{T,D} <: Real end
+
+"""
     UnionAbstractQuantity{T,D}
 
 This is a union of both `AbstractQuantity{T,D}` and `AbstractGenericQuantity{T,D}`.
@@ -64,7 +72,7 @@ It is used throughout the library to declare methods which can take both types.
 You should generally specialize on this type, rather than its constituents,
 as it will also include future abstract quantity types.
 """
-const UnionAbstractQuantity{T,D} = Union{AbstractQuantity{T,D},AbstractGenericQuantity{T,D}}
+const UnionAbstractQuantity{T,D} = Union{AbstractQuantity{T,D},AbstractGenericQuantity{T,D},AbstractRealQuantity{T,D}}
 
 """
     Dimensions{R<:Real} <: AbstractDimensions{R}
@@ -165,13 +173,36 @@ struct GenericQuantity{T,D<:AbstractDimensions} <: AbstractGenericQuantity{T,D}
 end
 
 """
+    RealQuantity{T<:Real,D<:AbstractDimensions} <: AbstractRealQuantity{T,D} <: Real
+
+This has the same behavior as `Quantity` but is subtyped to `AbstractRealQuantity <: Real`.
+"""
+struct RealQuantity{T<:Real,D<:AbstractDimensions} <: AbstractRealQuantity{T,D}
+    value::T
+    dimensions::D
+
+    RealQuantity(x::_T, dimensions::_D) where {_T,_D<:AbstractDimensions} = new{_T,_D}(x, dimensions)
+end
+
+"""
     ABSTRACT_QUANTITY_TYPES
 
 A constant tuple of the existing abstract quantity types,
 each as a tuple with (1) the abstract type,
 (2) the base type, and (3) the default exported concrete type.
 """
-const ABSTRACT_QUANTITY_TYPES = ((AbstractQuantity, Number, Quantity), (AbstractGenericQuantity, Any, GenericQuantity))
+const ABSTRACT_QUANTITY_TYPES = ((AbstractQuantity, Number, Quantity), (AbstractGenericQuantity, Any, GenericQuantity), (AbstractRealQuantity, Real, RealQuantity))
+
+"""
+    promote_quantity(::Type{<:UnionAbstractQuantity}, t::Type{<:Any})
+
+Find the next quantity type in the hierarchy that can accommodate the type `t`.
+If the current quantity type can already accommodate `t`, then the current type is returned.
+"""
+promote_quantity(::Type{<:Union{GenericQuantity,Quantity,RealQuantity}}, ::Type{<:Any}) = GenericQuantity
+promote_quantity(::Type{<:Union{Quantity,RealQuantity}}, ::Type{<:Number}) = Quantity
+promote_quantity(::Type{<:RealQuantity}, ::Type{<:Real}) = RealQuantity
+promote_quantity(T, _) = t
 
 for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
     @eval begin
@@ -189,7 +220,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
     end
 end
 
-const DEFAULT_QUANTITY_TYPE = Quantity{DEFAULT_VALUE_TYPE, DEFAULT_DIM_TYPE}
+const DEFAULT_QUANTITY_TYPE = RealQuantity{DEFAULT_VALUE_TYPE, DEFAULT_DIM_TYPE}
 
 new_dimensions(::Type{D}, dims...) where {D<:AbstractDimensions} = constructorof(D)(dims...)
 new_quantity(::Type{Q}, l, r) where {Q<:UnionAbstractQuantity} = constructorof(Q)(l, r)
@@ -208,6 +239,7 @@ if you need custom behavior.
 constructorof(::Type{<:Dimensions}) = Dimensions
 constructorof(::Type{<:Quantity}) = Quantity
 constructorof(::Type{<:GenericQuantity}) = GenericQuantity
+constructorof(::Type{<:RealQuantity}) = RealQuantity
 
 """
     with_type_parameters(::Type{<:AbstractDimensions}, ::Type{R})
@@ -225,6 +257,9 @@ function with_type_parameters(::Type{<:Quantity}, ::Type{T}, ::Type{D}) where {T
 end
 function with_type_parameters(::Type{<:GenericQuantity}, ::Type{T}, ::Type{D}) where {T,D}
     return GenericQuantity{T,D}
+end
+function with_type_parameters(::Type{<:RealQuantity}, ::Type{T}, ::Type{D}) where {T,D}
+    return RealQuantity{T,D}
 end
 
 # The following functions should be overloaded for special types

--- a/src/types.jl
+++ b/src/types.jl
@@ -214,7 +214,7 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
     end
 end
 
-const DEFAULT_QUANTITY_TYPE = RealQuantity{DEFAULT_VALUE_TYPE, DEFAULT_DIM_TYPE}
+const DEFAULT_QUANTITY_TYPE = Quantity{DEFAULT_VALUE_TYPE, DEFAULT_DIM_TYPE}
 
 @inline function new_dimensions(::Type{D}, dims...) where {D<:AbstractDimensions}
     return constructorof(D)(dims...)

--- a/src/types.jl
+++ b/src/types.jl
@@ -197,16 +197,6 @@ const ABSTRACT_QUANTITY_TYPES = (
     (AbstractRealQuantity, Real, RealQuantity)
 )
 
-"""
-    promote_quantity(::Type{<:UnionAbstractQuantity}, t::Type{<:Any})
-
-Find the next quantity type in the hierarchy that can accommodate the type `t`.
-If the current quantity type can already accommodate `t`, then the current type is returned.
-"""
-promote_quantity(::Type{<:Union{GenericQuantity,Quantity,RealQuantity}}, ::Type{<:Any}) = GenericQuantity
-promote_quantity(::Type{<:Union{Quantity,RealQuantity}}, ::Type{<:Number}) = Quantity
-promote_quantity(::Type{<:RealQuantity}, ::Type{<:Real}) = RealQuantity
-promote_quantity(T, _) = T
 
 for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
     @eval begin
@@ -230,7 +220,7 @@ const DEFAULT_QUANTITY_TYPE = RealQuantity{DEFAULT_VALUE_TYPE, DEFAULT_DIM_TYPE}
     return constructorof(D)(dims...)
 end
 @inline function new_quantity(::Type{Q}, val, dims) where {Q<:UnionAbstractQuantity}
-    Qout = promote_quantity(Q, typeof(val))
+    Qout = promote_quantity_on_value(Q, typeof(val))
     return constructorof(Qout)(val, dims)
 end
 

--- a/src/units.jl
+++ b/src/units.jl
@@ -3,7 +3,7 @@ module Units
 import ..DEFAULT_DIM_TYPE
 import ..DEFAULT_VALUE_TYPE
 import ..DEFAULT_QUANTITY_TYPE
-import ..Quantity
+import ..RealQuantity
 
 @assert DEFAULT_VALUE_TYPE == Float64 "`units.jl` must be updated to support a different default value type."
 

--- a/src/units.jl
+++ b/src/units.jl
@@ -3,7 +3,6 @@ module Units
 import ..DEFAULT_DIM_TYPE
 import ..DEFAULT_VALUE_TYPE
 import ..DEFAULT_QUANTITY_TYPE
-import ..RealQuantity
 
 @assert DEFAULT_VALUE_TYPE == Float64 "`units.jl` must be updated to support a different default value type."
 

--- a/src/uparse.jl
+++ b/src/uparse.jl
@@ -1,6 +1,7 @@
 module UnitsParse
 
-import ..RealQuantity
+import ..constructorof
+import ..DEFAULT_QUANTITY_TYPE
 import ..DEFAULT_DIM_TYPE
 import ..DEFAULT_VALUE_TYPE
 import ..Units: UNIT_SYMBOLS
@@ -24,8 +25,8 @@ end
     uparse(s::AbstractString)
 
 Parse a string containing an expression of units and return the
-corresponding `RealQuantity` object with `Float64` value. For example,
-`uparse("m/s")` would be parsed to `RealQuantity(1.0, length=1, time=-1)`.
+corresponding `Quantity` object with `Float64` value. For example,
+`uparse("m/s")` would be parsed to `Quantity(1.0, length=1, time=-1)`.
 
 Note that inside this expression, you also have access to the `Constants`
 module. So, for example, `uparse("Constants.c^2 * Hz^2")` would evaluate to
@@ -33,19 +34,19 @@ the quantity corresponding to the speed of light multiplied by Hertz,
 squared.
 """
 function uparse(s::AbstractString)
-    return as_quantity(eval(Meta.parse(s)))::RealQuantity{DEFAULT_VALUE_TYPE,DEFAULT_DIM_TYPE}
+    return as_quantity(eval(Meta.parse(s)))::DEFAULT_QUANTITY_TYPE
 end
 
-as_quantity(q::RealQuantity) = q
-as_quantity(x::Number) = RealQuantity(convert(DEFAULT_VALUE_TYPE, x), DEFAULT_DIM_TYPE)
+as_quantity(q::DEFAULT_QUANTITY_TYPE) = q
+as_quantity(x::Number) = convert(DEFAULT_QUANTITY_TYPE,  x)
 as_quantity(x) = error("Unexpected type evaluated: $(typeof(x))")
 
 """
     u"[unit expression]"
 
 Parse a string containing an expression of units and return the
-corresponding `RealQuantity` object with `Float64` value. For example,
-`u"km/s^2"` would be parsed to `RealQuantity(1000.0, length=1, time=-2)`.
+corresponding `Quantity` object with `Float64` value. For example,
+`u"km/s^2"` would be parsed to `Quantity(1000.0, length=1, time=-2)`.
 
 Note that inside this expression, you also have access to the `Constants`
 module. So, for example, `u"Constants.c^2 * Hz^2"` would evaluate to

--- a/src/uparse.jl
+++ b/src/uparse.jl
@@ -1,6 +1,6 @@
 module UnitsParse
 
-import ..Quantity
+import ..RealQuantity
 import ..DEFAULT_DIM_TYPE
 import ..DEFAULT_VALUE_TYPE
 import ..Units: UNIT_SYMBOLS
@@ -24,8 +24,8 @@ end
     uparse(s::AbstractString)
 
 Parse a string containing an expression of units and return the
-corresponding `Quantity` object with `Float64` value. For example,
-`uparse("m/s")` would be parsed to `Quantity(1.0, length=1, time=-1)`.
+corresponding `RealQuantity` object with `Float64` value. For example,
+`uparse("m/s")` would be parsed to `RealQuantity(1.0, length=1, time=-1)`.
 
 Note that inside this expression, you also have access to the `Constants`
 module. So, for example, `uparse("Constants.c^2 * Hz^2")` would evaluate to
@@ -33,19 +33,19 @@ the quantity corresponding to the speed of light multiplied by Hertz,
 squared.
 """
 function uparse(s::AbstractString)
-    return as_quantity(eval(Meta.parse(s)))::Quantity{DEFAULT_VALUE_TYPE,DEFAULT_DIM_TYPE}
+    return as_quantity(eval(Meta.parse(s)))::RealQuantity{DEFAULT_VALUE_TYPE,DEFAULT_DIM_TYPE}
 end
 
-as_quantity(q::Quantity) = q
-as_quantity(x::Number) = Quantity(convert(DEFAULT_VALUE_TYPE, x), DEFAULT_DIM_TYPE)
+as_quantity(q::RealQuantity) = q
+as_quantity(x::Number) = RealQuantity(convert(DEFAULT_VALUE_TYPE, x), DEFAULT_DIM_TYPE)
 as_quantity(x) = error("Unexpected type evaluated: $(typeof(x))")
 
 """
     u"[unit expression]"
 
 Parse a string containing an expression of units and return the
-corresponding `Quantity` object with `Float64` value. For example,
-`u"km/s^2"` would be parsed to `Quantity(1000.0, length=1, time=-2)`.
+corresponding `RealQuantity` object with `Float64` value. For example,
+`u"km/s^2"` would be parsed to `RealQuantity(1000.0, length=1, time=-2)`.
 
 Note that inside this expression, you also have access to the `Constants`
 module. So, for example, `u"Constants.c^2 * Hz^2"` would evaluate to

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -105,17 +105,12 @@ for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
     end
 end
 
-for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
+for (type, _, _) in ABSTRACT_QUANTITY_TYPES
     @eval begin
         function (::Type{T})(q::$type) where {T<:Number}
+            q isa T && return q
             @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
             return convert(T, ustrip(q))
-        end
-        function Base.convert(::Type{T}, q::$type) where {T<:Number}
-            return T(q)
-        end
-        function Base.convert(::Type{$base_type}, q::$type)
-            return q
         end
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -87,17 +87,14 @@ end
 # abstract number packages which may try to do the same thing.
 # (which would lead to ambiguities)
 const BASE_NUMERIC_TYPES = Union{
-    Int8, UInt8, Int16, UInt16, Int32, UInt32,
+    Bool, Int8, UInt8, Int16, UInt16, Int32, UInt32,
     Int64, UInt64, Int128, UInt128, Float16, Float32,
-    Float64, BigInt, ComplexF16, ComplexF32,
+    Float64, BigFloat, BigInt, ComplexF16, ComplexF32,
     ComplexF64, Complex{BigFloat}, Rational{Int8}, Rational{UInt8},
     Rational{Int16}, Rational{UInt16}, Rational{Int32}, Rational{UInt32},
     Rational{Int64}, Rational{UInt64}, Rational{Int128}, Rational{UInt128},
     Rational{BigInt},
 }
-# The following types require explicit promotion,
-# as putting them in a union type creates different ambiguities
-const AMBIGUOUS_NUMERIC_TYPES = (Bool, BigFloat)
 
 for (type, _, _) in ABSTRACT_QUANTITY_TYPES 
     @eval begin
@@ -109,19 +106,6 @@ for (type, _, _) in ABSTRACT_QUANTITY_TYPES
         end
         function Base.promote_rule(::Type{T2}, ::Type{Q}) where {T,D,Q<:$type{T,D},T2<:BASE_NUMERIC_TYPES}
             return with_type_parameters(promote_quantity_on_value(Q, T2), promote_type(T, T2), D)
-        end
-    end
-    for numeric_type in AMBIGUOUS_NUMERIC_TYPES
-        @eval begin
-            function Base.convert(::Type{Q}, x::$numeric_type) where {T,D,Q<:$type{T,D}}
-                return new_quantity(Q, convert(T, x), D())
-            end
-            function Base.promote_rule(::Type{Q}, ::Type{$numeric_type}) where {T,D,Q<:$type{T,D}}
-                return with_type_parameters(promote_quantity_on_value(Q, $numeric_type), promote_type(T, $numeric_type), D)
-            end
-            function Base.promote_rule(::Type{$numeric_type}, ::Type{Q}) where {T,D,Q<:$type{T,D}}
-                return with_type_parameters(promote_quantity_on_value(Q, $numeric_type), promote_type(T, $numeric_type), D)
-            end
         end
     end
 end
@@ -175,7 +159,7 @@ Base.keys(q::UnionAbstractQuantity) = keys(ustrip(q))
 
 
 # Numeric checks
-for op in (:(<=), :(<), :(>=), :(>), :isless, :isgreater),
+for op in (:(<=), :(<), :(>=), :(>), :isless),
     (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
 
     @eval begin
@@ -247,7 +231,7 @@ end
 
 # Simple flags:
 for f in (
-    :iszero, :isfinite, :isinf, :isnan, :isreal, :signbit,
+    :isone, :iszero, :isfinite, :isinf, :isnan, :isreal, :signbit,
     :isempty, :iseven, :isodd, :isinteger, :ispow2
 )
     @eval Base.$f(q::UnionAbstractQuantity) = $f(ustrip(q))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -141,7 +141,8 @@ Base.keys(q::UnionAbstractQuantity) = keys(ustrip(q))
 # Numeric checks
 function Base.isapprox(l::UnionAbstractQuantity, r::UnionAbstractQuantity; kws...)
     l, r = promote_except_value(l, r)
-    return isapprox(ustrip(l), ustrip(r); kws...) && dimension(l) == dimension(r)
+    dimension(l) == dimension(r) || throw(DimensionError(l, r))
+    return isapprox(ustrip(l), ustrip(r); kws...)
 end
 function Base.isapprox(l::Number, r::UnionAbstractQuantity; kws...)
     iszero(dimension(r)) || throw(DimensionError(l, r))
@@ -151,7 +152,6 @@ function Base.isapprox(l::UnionAbstractQuantity, r::Number; kws...)
     iszero(dimension(l)) || throw(DimensionError(l, r))
     return isapprox(ustrip(l), r; kws...)
 end
-Base.iszero(d::AbstractDimensions) = all_dimensions(iszero, d)
 function Base.:(==)(l::UnionAbstractQuantity, r::UnionAbstractQuantity)
     l, r = promote_except_value(l, r)
     ustrip(l) == ustrip(r) && dimension(l) == dimension(r)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -25,7 +25,9 @@ end
     return output
 end
 
-Base.convert(::Type{Number}, q::AbstractQuantity) = q
+for (type, base_type, _) in ABSTRACT_QUANTITY_TYPES
+    @eval Base.convert(::Type{$base_type}, q::$type) = q
+end
 function Base.convert(::Type{T}, q::UnionAbstractQuantity) where {T<:Number}
     @assert iszero(dimension(q)) "$(typeof(q)): $(q) has dimensions! Use `ustrip` instead."
     return convert(T, ustrip(q))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -35,14 +35,10 @@ end
 function Base.promote_rule(::Type{Dimensions{R1}}, ::Type{Dimensions{R2}}) where {R1,R2}
     return Dimensions{promote_type(R1,R2)}
 end
-function Base.promote_rule(::Type{<:GenericQuantity{T1,D1}}, ::Type{<:GenericQuantity{T2,D2}}) where {T1,T2,D1,D2}
-    return GenericQuantity{promote_type(T1,T2),promote_type(D1,D2)}
-end
-function Base.promote_rule(::Type{<:Quantity{T1,D1}}, ::Type{<:Quantity{T2,D2}}) where {T1,T2,D1,D2}
-    return Quantity{promote_type(T1,T2),promote_type(D1,D2)}
-end
-function Base.promote_rule(::Type{<:RealQuantity{T1,D1}}, ::Type{<:RealQuantity{T2,D2}}) where {T1,T2,D1,D2}
-    return RealQuantity{promote_type(T1,T2),promote_type(D1,D2)}
+for (_, _, concrete_type) in ABSTRACT_QUANTITY_TYPES
+    @eval function Base.promote_rule(::Type{<:$concrete_type{T1,D1}}, ::Type{<:$concrete_type{T2,D2}}) where {T1,T2,D1,D2}
+        return $concrete_type{promote_type(T1,T2),promote_type(D1,D2)}
+    end
 end
 
 function Base.promote_rule(::Type{<:Quantity{T1,D1}}, ::Type{<:GenericQuantity{T2,D2}}) where {T1,T2,D1,D2}

--- a/test/test_measurements.jl
+++ b/test/test_measurements.jl
@@ -2,7 +2,7 @@ using DynamicQuantities
 using Measurements
 using Measurements: value, uncertainty
 
-for Q in (Quantity, GenericQuantity)
+for Q in (RealQuantity, Quantity, GenericQuantity)
     x = Q(1.0u"m/s") ± Q(0.1u"m/s")
 
     @test ustrip(x^2) == ustrip(x)^2
@@ -11,7 +11,9 @@ for Q in (Quantity, GenericQuantity)
     @test dimension(x)^2 == dimension(x^2)
     @test_throws DimensionError 0.5u"m" ± 0.1u"s"
 
-    # Mixed types:
-    y = Q{Float16}(0.1u"m/s") ± Q{Float32}(0.1u"m/s")
-    @test typeof(y) <: Q{Measurement{Float32}}
+    if Q in (Quantity, GenericQuantity)
+        # Mixed types:
+        y = Q{Float16}(0.1u"m/s") ± Q{Float32}(0.1u"m/s")
+        @test typeof(y) <: Q{Measurement{Float32}}
+    end
 end

--- a/test/test_scitypes.jl
+++ b/test/test_scitypes.jl
@@ -1,4 +1,5 @@
 using DynamicQuantities
+using DynamicQuantities: DEFAULT_QUANTITY_TYPE, constructorof
 using ScientificTypes
 import ScientificTypes as ST
 
@@ -18,6 +19,6 @@ sch = schema(X)
 
 @test first(sch.names) == :x
 @test first(sch.scitypes) == Continuous
-@test first(sch.types) <: Quantity{Float64}
+@test first(sch.types) <: constructorof(DEFAULT_QUANTITY_TYPE){Float64}
 
 @test first(schema((; x=rand(1:10, 5) .* Quantity{Int}(u"m/s"))).scitypes) == Count

--- a/test/test_unitful.jl
+++ b/test/test_unitful.jl
@@ -6,10 +6,10 @@ import Ratios: SimpleRatio
 import SaferIntegers: SafeInt16
 using Test
 
-risapprox(x::Unitful.Quantity, y::Unitful.Quantity; kws...) =
-    let (xfloat, yfloat) = (Unitful.ustrip ∘ Unitful.upreferred).((x, y))
-        return isapprox(xfloat, yfloat; kws...)
-    end
+function risapprox(x::Unitful.Quantity, y::Unitful.Quantity; kws...)
+    (xfloat, yfloat) = (Unitful.ustrip ∘ Unitful.upreferred).((x, y))
+    return isapprox(xfloat, yfloat; kws...)
+end
 
 for T in [DEFAULT_VALUE_TYPE, Float16, Float32, Float64], R in [DEFAULT_DIM_BASE_TYPE, Rational{Int16}, Rational{Int32}, SimpleRatio{Int}, SimpleRatio{SafeInt16}]
     D = DynamicQuantities.Dimensions{R}

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -189,6 +189,12 @@ end
 
 end
 
+@testset "Ranges" begin
+    x = [xi for xi in 0.0u"km/s":0.1u"km/s":1.0u"km/s"]
+    @test x[2] == 0.1u"km/s"
+    @test x[end] == 1.0u"km/s"
+end
+
 @testset "Complex numbers" begin
     x = (0.5 + 0.6im) * u"km/s"
     @test string(x) == "(500.0 + 600.0im) m s⁻¹"

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -97,7 +97,7 @@ end
 
         y = Q(T(2 // 10), D, length=1, mass=6 // 2)
 
-        @test !(y ≈ x)
+        @test !(unsafe_isapprox(y, x))
 
         y = x * Inf32
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1258,9 +1258,9 @@ end
     functions = (
         :float, :abs, :real, :imag, :conj, :adjoint, :unsigned,
         :nextfloat, :prevfloat, :identity, :transpose,
-        :copysign, :flipsign, :mod, :modf,
+        :copysign, :flipsign, :modf,
         :floor, :trunc, :ceil, :significand,
-        :ldexp, :round,
+        :ldexp, :round, # :mod
     )
     for Q in (RealQuantity, Quantity, GenericQuantity), D in (Dimensions, SymbolicDimensions), f in functions
         T = f in (:abs, :real, :imag, :conj) ? ComplexF64 : Float64
@@ -1274,7 +1274,7 @@ end
                     @eval @test $f($qx_dimensions)[$i] == $Q($f($x)[$i], $dim)
                 end
             end
-        elseif f in (:copysign, :flipsign, :rem, :mod)  # Functions that need multiple inputs
+        elseif f in (:copysign, :flipsign, :rem)  # Functions that need multiple inputs
             for x in 5rand(T, 3) .- 2.5
                 for y in 5rand(T, 3) .- 2.5
                     dim = convert(D, dimension(u"m/s"))

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1319,7 +1319,7 @@ end
                         @eval @test $f($qx_dimensionless, $y) ≈ $Q($f($x, $y), $D)
                         @eval @test_throws DimensionError $f($qx_dimensions, $y)
                         @eval @test_throws DimensionError $f($x, $qy_dimensions)
-                        if f == :rem
+                        if f == :rem && VERSION >= v"1.9"
                             # Can also do other rounding modes
                             for r in (:RoundFromZero, :RoundNearest, :RoundUp, :RoundDown)
                                 @eval @test $f($qx_dimensions, $qy_dimensions, $r) ≈ $Q($f($x, $y, $r), $dim)

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -863,8 +863,8 @@ end
             x = Q(1.0u"1")
             @test Bool(x) == true
             @test Bool(ustrip(x)) == true
-            @test Bool(Q(0.0u"m")) == false
-            @test Bool(ustrip(Q(0.0u"m"))) == false
+            @test Bool(Q(0.0u"1")) == false
+            @test Bool(ustrip(Q(0.0u"1"))) == false
             x = Q(1.0u"m")
             @test_throws AssertionError Bool(x)
         end
@@ -1315,14 +1315,14 @@ end
                         # Also do test without dimensions (need dimensionless)
                         qx_dimensionless = Q(x, D)
                         qy_dimensionless = Q(y, D)
-                        @eval @test $f($x, $qy_dimensionless) == $Q($f($x, $y), $D)
-                        @eval @test $f($qx_dimensionless, $y) == $Q($f($x, $y), $D)
+                        @eval @test $f($x, $qy_dimensionless) ≈ $Q($f($x, $y), $D)
+                        @eval @test $f($qx_dimensionless, $y) ≈ $Q($f($x, $y), $D)
                         @eval @test_throws DimensionError $f($qx_dimensions, $y)
                         @eval @test_throws DimensionError $f($x, $qy_dimensions)
                         if f == :rem
                             # Can also do other rounding modes
                             for r in (:RoundFromZero, :RoundNearest, :RoundUp, :RoundDown)
-                                @eval @test $f($qx_dimensions, $qy_dimensions, $r) == $Q($f($x, $y, $r), $dim)
+                                @eval @test $f($qx_dimensions, $qy_dimensions, $r) ≈ $Q($f($x, $y, $r), $dim)
                             end
                         end
                     end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -848,7 +848,7 @@ end
             @test typeof(out) == with_type_parameters(promote_quantity_on_value(Q, ComplexF64), Complex{Float64}, DEFAULT_DIM_TYPE)
             @test ustrip(out) ≈ 0.5 ^ (1 + 2im)
 
-            for CT in (Complex, Complex{Float32})
+            for CT in (Complex, Complex{Bool})
                 x = Q(1.0)
                 @test CT(x) == CT(1.0)
                 @test typeof(CT(x)) <: CT

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -499,7 +499,7 @@ end
     @eval struct MyNumber <: Real
         x::Float64
     end
-    a = 0.5u"km/s"
+    a = RealQuantity(0.5u"km/s")
     b = MyNumber(0.5)
     ar = [a, b]
     @test ar isa Vector{Real}
@@ -704,13 +704,13 @@ end
     @test_throws DimensionError uconvert(us"nm * J", 5e-9u"m")
 
     # Types:
-    @test typeof(uconvert(us"nm", 5e-9u"m")) <: RealQuantity{Float64,<:SymbolicDimensions}
+    @test typeof(uconvert(us"nm", 5e-9u"m")) <: constructorof(DEFAULT_QUANTITY_TYPE){Float64,<:SymbolicDimensions}
     @test typeof(uconvert(us"nm", GenericQuantity(5e-9u"m"))) <: GenericQuantity{Float64,<:SymbolicDimensions}
     @test uconvert(GenericQuantity(us"nm"), GenericQuantity(5e-9u"m")) ≈ 5us"nm"
     @test uconvert(GenericQuantity(us"nm"), GenericQuantity(5e-9u"m")) ≈ GenericQuantity(5us"nm")
 
     # We only want to convert the dimensions, and ignore the quantity type:
-    @test typeof(uconvert(GenericQuantity(us"nm"), 5e-9u"m")) <: RealQuantity{Float64,<:SymbolicDimensions}
+    @test typeof(uconvert(GenericQuantity(us"nm"), 5e-9u"m")) <: constructorof(DEFAULT_QUANTITY_TYPE){Float64,<:SymbolicDimensions}
 
     q = 1.5u"Constants.M_sun"
     qs = uconvert(us"Constants.M_sun", 5.0 * q)
@@ -803,7 +803,7 @@ end
     end
 
     @testset "Rational power law" begin
-        x = 1.0u"m"
+        x = RealQuantity(1.0u"m")
         y = x ^ (3//2)
         @test y == Quantity(1.0, length=3//2)
         @test typeof(y) == RealQuantity{Float64,DEFAULT_DIM_TYPE}
@@ -1201,8 +1201,8 @@ end
         qy = QuantityArray(y; length=1)
 
         @test typeof(convert(typeof(qx), qy)) == typeof(qx)
-        @test convert(typeof(qx), qy)[1] isa RealQuantity{Float64}
-        @test convert(typeof(qx), qy)[1] == convert(RealQuantity{Float64}, qy[1])
+        @test convert(typeof(qx), qy)[1] isa Quantity{Float64}
+        @test convert(typeof(qx), qy)[1] == convert(Quantity{Float64}, qy[1])
     end
 end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -515,6 +515,8 @@ end
     @test promote_type(GenericQuantity{Float32,D}, GenericQuantity{Float64,D}) == GenericQuantity{Float64,D}
     @test promote_type(SymbolicDimensions{Rational{Int}}, SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}) == SymbolicDimensions{Rational{Int}}
     @test promote_type(Dimensions{Rational{Int}}, SymbolicDimensions{DEFAULT_DIM_BASE_TYPE}) == Dimensions{Rational{Int}}
+
+    @test promote_quantity_on_quantity(RealQuantity, RealQuantity) == RealQuantity
 end
 
 struct MyDimensions{R} <: AbstractDimensions{R}
@@ -777,12 +779,13 @@ end
         @test promote_type(typeof(u"km/s"), typeof(convert(Quantity{Float32}, u"km/s"))) <: Quantity{Float64}
 
         x = FixedRational{Int32,100}(1)
-        @test promote_type(typeof(x), typeof(true)) == typeof(x)
-        @test promote_type(typeof(true), typeof(x)) == typeof(x)
-        @test promote_type(typeof(x), typeof(BigFloat(1))) == promote_type(Rational{Int32}, BigFloat)
-        @test promote_type(typeof(BigFloat(1)), typeof(x)) == promote_type(Rational{Int32}, BigFloat)
-        @test promote_type(typeof(x), typeof(π)) == promote_type(Rational{Int32}, typeof(π))
-        @test promote_type(typeof(π), typeof(x)) == promote_type(Rational{Int32}, typeof(π))
+        # Need explicit `promote_rule` calls here so coverage picks it up
+        @test promote_rule(typeof(x), typeof(true)) == typeof(x)
+        @test promote_rule(typeof(true), typeof(x)) == typeof(x)
+        @test promote_rule(typeof(x), typeof(BigFloat(1))) == promote_type(Rational{Int32}, BigFloat)
+        @test promote_rule(typeof(BigFloat(1)), typeof(x)) == promote_type(Rational{Int32}, BigFloat)
+        @test promote_rule(typeof(x), typeof(π)) == promote_type(Rational{Int32}, typeof(π))
+        @test promote_rule(typeof(π), typeof(x)) == promote_type(Rational{Int32}, typeof(π))
     end
 
     @testset "Weakref" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -205,13 +205,13 @@ end
     @test adjoint(ustrip(x^2)) ≈ adjoint(x^2) / u"m/s"^2
 
     # Can create by division as well:
-    x = 1.0u"km/s" / (1.0 + 0.5im)
+    x = RealQuantity(1.0u"km/s") / (1.0 + 0.5im)
     @test typeof(x) == Quantity{Complex{Float64}, DEFAULT_DIM_TYPE}
     @test ustrip(x) ≈ 1000.0 / (1.0 + 0.5im)
     @test ulength(x) == 1.0
     @test utime(x) == -1.0
 
-    x = (1.0 + 0.5im) / (1.0u"km/s")
+    x = (1.0 + 0.5im) / RealQuantity(1.0u"km/s")
     @test typeof(x) == Quantity{Complex{Float64}, DEFAULT_DIM_TYPE}
     @test ustrip(x) ≈ (1.0 + 0.5im) / 1000.0
     @test ulength(x) == -1.0

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -3,6 +3,7 @@ using DynamicQuantities: FixedRational
 using DynamicQuantities: DEFAULT_QUANTITY_TYPE, DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
 using DynamicQuantities: array_type, value_type, dim_type, quantity_type
 using DynamicQuantities: GenericQuantity, with_type_parameters, constructorof
+using DynamicQuantities: promote_quantity_on_quantity, promote_quantity_on_value
 using Ratios: SimpleRatio
 using SaferIntegers: SafeInt16
 using StaticArrays: SArray, MArray
@@ -169,6 +170,8 @@ end
     @test iseven(Quantity(3, length=1)) == false
     @test isodd(Quantity(2, length=1)) == false
     @test isodd(Quantity(3, length=1)) == true
+    @test isone(Quantity(1, length=1)) == true
+    @test isone(Quantity(2, length=1)) == false
     @test isinteger(Quantity(2, length=1)) == true
     @test isinteger(Quantity(2.1, length=1)) == false
     @test ispow2(Quantity(2, length=1)) == true
@@ -200,6 +203,19 @@ end
     @test conj(x) == (0.5 - 0.6im) * u"km/s"
     @test angle(x) == angle(ustrip(x))
     @test adjoint(ustrip(x^2)) ≈ adjoint(x^2) / u"m/s"^2
+
+    # Can create by division as well:
+    x = 1.0u"km/s" / (1.0 + 0.5im)
+    @test typeof(x) == Quantity{Complex{Float64}, DEFAULT_DIM_TYPE}
+    @test ustrip(x) ≈ 1000.0 / (1.0 + 0.5im)
+    @test ulength(x) == 1.0
+    @test utime(x) == -1.0
+
+    x = (1.0 + 0.5im) / (1.0u"km/s")
+    @test typeof(x) == Quantity{Complex{Float64}, DEFAULT_DIM_TYPE}
+    @test ustrip(x) ≈ (1.0 + 0.5im) / 1000.0
+    @test ulength(x) == -1.0
+    @test utime(x) == 1.0
 end
 
 @testset "Fallbacks" begin
@@ -561,6 +577,9 @@ end
 
     # But, we always need to use a quantity when mixing with mathematical operations:
     @test_throws ErrorException MyQuantity(0.1) + 0.1 * MyDimensions()
+
+    # Explicitly test that `promote_quantity_on_quantity` has a reasonable default
+    @test promote_quantity_on_quantity(typeof(MyQuantity(0.1)), typeof(MyQuantity(0.1))) == MyQuantity{Float64,DEFAULT_DIM_TYPE}
 end
 
 @testset "Symbolic dimensions" begin
@@ -749,27 +768,71 @@ end
 
 
 @testset "Test ambiguities" begin
-    R = DEFAULT_DIM_BASE_TYPE
-    x = convert(R, 10)
-    y = convert(R, 5)
-    @test promote(x, y) == (x, y)
-    @test_throws ErrorException promote(x, convert(FixedRational{Int32,100}, 10))
-    @test promote_type(typeof(u"km/s"), typeof(convert(Quantity{Float32}, u"km/s"))) <: Quantity{Float64}
+    @testset "FixedRational" begin
+        R = DEFAULT_DIM_BASE_TYPE
+        x = convert(R, 10)
+        y = convert(R, 5)
+        @test promote(x, y) == (x, y)
+        @test_throws ErrorException promote(x, convert(FixedRational{Int32,100}, 10))
+        @test promote_type(typeof(u"km/s"), typeof(convert(Quantity{Float32}, u"km/s"))) <: Quantity{Float64}
 
-    x = 1.0u"m"
-    s = "test"
-    y = WeakRef(s)
-    @test_throws ErrorException x == y
-    @test_throws ErrorException y == x
+        x = FixedRational{Int32,100}(1)
+        @test promote_type(typeof(x), typeof(true)) == typeof(x)
+        @test promote_type(typeof(true), typeof(x)) == typeof(x)
+        @test promote_type(typeof(x), typeof(BigFloat(1))) == promote_type(Rational{Int32}, BigFloat)
+        @test promote_type(typeof(BigFloat(1)), typeof(x)) == promote_type(Rational{Int32}, BigFloat)
+        @test promote_type(typeof(x), typeof(π)) == promote_type(Rational{Int32}, typeof(π))
+        @test promote_type(typeof(π), typeof(x)) == promote_type(Rational{Int32}, typeof(π))
+    end
 
-    qarr1 = QuantityArray(randn(3), u"km/s")
-    qarr2 = qarr1
-    @test convert(typeof(qarr2), qarr2) === qarr1
+    @testset "Weakref" begin
+        x = 1.0u"m"
+        s = "test"
+        y = WeakRef(s)
+        @test_throws ErrorException x == y
+        @test_throws ErrorException y == x
+    end
 
-    x = 1.0u"m"
-    y = x ^ (3//2)
-    @test y == Quantity(1.0, length=3//2)
-    @test typeof(y) == RealQuantity{Float64,DEFAULT_DIM_TYPE}
+    @testset "Arrays" begin
+        qarr1 = QuantityArray(randn(3), u"km/s")
+        qarr2 = qarr1
+        @test convert(typeof(qarr2), qarr2) === qarr1
+    end
+
+    @testset "Rational power law" begin
+        x = 1.0u"m"
+        y = x ^ (3//2)
+        @test y == Quantity(1.0, length=3//2)
+        @test typeof(y) == RealQuantity{Float64,DEFAULT_DIM_TYPE}
+    end
+
+    @testset "Numeric promotion rules" begin
+        for Q in (RealQuantity, Quantity, GenericQuantity)
+            x = Q(1.0u"m")
+            @test promote_type(typeof(x), Bool) == typeof(x)
+            @test promote_type(Bool, typeof(x)) == typeof(x)
+            @test promote_type(typeof(x), BigFloat) == with_type_parameters(Q, BigFloat, DEFAULT_DIM_TYPE)
+            @test promote_type(BigFloat, typeof(x)) == with_type_parameters(Q, BigFloat, DEFAULT_DIM_TYPE)
+        end
+    end
+
+    @testset "Complex numbers" begin
+        for Q in (RealQuantity, Quantity, GenericQuantity)
+            # Bool stuff
+            x = true * im
+            y = Q(0.5u"m")
+            @test typeof(x * y) == with_type_parameters(promote_quantity_on_value(Q, ComplexF64), Complex{Float64}, DEFAULT_DIM_TYPE)
+            @test typeof(y * x) == with_type_parameters(promote_quantity_on_value(Q, ComplexF64), Complex{Float64}, DEFAULT_DIM_TYPE)
+            @test ustrip(x * y) == 0.5im
+            @test ustrip(y * x) == 0.5im
+
+            # Complex powers
+            x = Q(0.5u"1")
+            out = x ^ (1 + 2im)
+            @test typeof(out) == with_type_parameters(promote_quantity_on_value(Q, ComplexF64), Complex{Float64}, DEFAULT_DIM_TYPE)
+            @test ustrip(out) ≈ 0.5 ^ (1 + 2im)
+        end
+    end
 end
 
 for Q in (RealQuantity, Quantity, GenericQuantity)
@@ -1251,6 +1314,40 @@ end
     end
 end
 
+@testset "Assorted comparison functions" begin
+    functions = (
+        :(<=), :(<), :(>=), :(>), :isless, :isequal, :(==),
+    )
+    x = 5randn(10) .- 2.5
+    y = 5randn(10) .- 2.5
+    for Q in (RealQuantity, Quantity, GenericQuantity), D in (Dimensions, SymbolicDimensions), f in functions
+        ground_truth = @eval $f.($x, $y)
+        dim = convert(D, dimension(u"m/s"))
+        qx_dimensions = [Q(xi, dim) for xi in x]
+        qy_dimensions = [Q(yi, dim) for yi in y]
+        @eval @test all($f.($qx_dimensions, $qy_dimensions) .== $ground_truth)
+        if f in (:isequal, :(==))
+            # These include a dimension check in the result, rather than
+            # throwing an error
+            @eval @test !any($f.($qx_dimensions, $y))
+            @eval @test !any($f.($x, $qy_dimensions))
+        else
+            @eval @test_throws DimensionError $f($qx_dimensions[1], $y[1])
+            @eval @test_throws DimensionError $f($x[1], $qy_dimensions[1])
+        end
+        qx_dimensionless = [Q(xi, D) for xi in x]
+        qy_dimensionless = [Q(yi, D) for yi in y]
+        @eval @test all($f.($qx_dimensionless, $y) .== $ground_truth)
+        @eval @test all($f.($x, $qy_dimensionless) .== $ground_truth)
+
+        qx_real_dimensions = [RealQuantity(xi, dim) for xi in x]
+        qy_real_dimensions = [RealQuantity(yi, dim) for yi in y]
+        # Mixed quantity input
+        @eval @test all($f.($qx_real_dimensions, $qy_dimensions) .== $ground_truth)
+        @eval @test all($f.($qx_dimensions, $qy_real_dimensions) .== $ground_truth)
+    end
+end
+
 @testset "Test div" begin
     for Q in (RealQuantity, Quantity, GenericQuantity)
         x = Q{Int}(10, length=1)
@@ -1263,5 +1360,13 @@ end
             @test div(x, 3, RoundFromZero) == Q{Int}(4, length=1)
             @test div(10, y, RoundFromZero) == Q{Int}(4, mass=1)
         end
+    end
+    # Also test mixed quantities:
+    x = RealQuantity{Int}(10, length=1)
+    y = Quantity{Int}(3, mass=-1)
+    @test div(x, y) == Quantity{Int}(3, length=1, mass=1)
+    @test typeof(div(x, y)) <: Quantity{Int}
+    if VERSION >= v"1.9"
+        @test div(x, y, RoundFromZero) == Quantity{Int}(4, length=1, mass=1)
     end
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -14,6 +14,9 @@ function record_show(s, f=show)
     f(io, s)
     return String(take!(io))
 end
+function unsafe_isapprox(x, y; kwargs...)
+    return isapprox(ustrip(x), ustrip(y); kwargs...) && dimension(x) == dimension(y)
+end
 
 @testset "Basic utilities" begin
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -821,7 +821,14 @@ end
 
     @testset "Complex numbers" begin
         for Q in (RealQuantity, Quantity, GenericQuantity)
-            # Bool stuff
+            x = 1.0im
+            y = Q(0.5u"m")
+            @test typeof(x * y) == with_type_parameters(promote_quantity_on_value(Q, ComplexF64), Complex{Float64}, DEFAULT_DIM_TYPE)
+            @test typeof(y * x) == with_type_parameters(promote_quantity_on_value(Q, ComplexF64), Complex{Float64}, DEFAULT_DIM_TYPE)
+            @test ustrip(x * y) == 0.5im
+            @test ustrip(y * x) == 0.5im
+
+            # Bool version
             x = true * im
             y = Q(0.5u"m")
             @test typeof(x * y) == with_type_parameters(promote_quantity_on_value(Q, ComplexF64), Complex{Float64}, DEFAULT_DIM_TYPE)


### PR DESCRIPTION
This adds a new `AbstractRealQuantity <: Real` and a concrete type `RealQuantity`. Users can wrap quantities with `RealQuantity(0.3u"km/s")` to pass to functions that require real input. But the default would still be `Quantity <: Number` for reasons discussed [here](https://github.com/SymbolicML/DynamicQuantities.jl/pull/85#issuecomment-1820307355).

I also introduce a new function `promote_quantity` which one can overload as a sort of custom type hierarchy, so that `RealQuantity -> Quantity` if it interacts with a non-real, and `{RealQuantity,Quantity} -> GenericQuantity` if they interact with non-numeric.

~~However this is a bit of a mess right now due to promotion complexities, making `(0.3+2im)u"km/s"` promote to a `Complex{<:Quantity}` instead of a `Quantity`... Anybody interested in having a go?~~ Fixed!