### PR TITLE
Add missing `Base.similar(::QuantityArray, ...)` definition

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,6 @@ jobs:
           julia --color=yes coverage.jl
       - name: "Coveralls"
         uses: coverallsapp/github-action@v2
-        if: matrix.version == '1'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           file: lcov.info

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -213,10 +213,13 @@ end
 # we need to overload it for QuantityArray.
 Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.HasShape, axs) where {T} =
     QuantityArray(similar(ustrip(c), value_type(T), axs), dimension(materialize_first(itr))::dim_type(T), T)
-Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.SizeUnknown, ::Nothing) where {T} =
-    QuantityArray(similar(ustrip(c), value_type(T), 0), dimension(materialize_first(itr))::dim_type(T), T)
-Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.HasLength, len::Integer) where {T} =
-    QuantityArray(similar(ustrip(c), value_type(T), len), dimension(materialize_first(itr))::dim_type(T), T)
+
+# These methods are not yet implemented, but the default implementation is dangerous,
+# as it may cause a stack overflow, so we raise a more helpful error instead.
+Base._similar_for(::QuantityArray, ::Type{T}, _, ::Base.SizeUnknown, ::Nothing) where {T} =
+    error("Not implemented. Please raise an issue on DynamicQuantities.jl.")
+Base._similar_for(::QuantityArray, ::Type{T}, _, ::Base.HasLength, ::Integer) where {T} =
+    error("Not implemented. Please raise an issue on DynamicQuantities.jl.")
 
 # In earlier Julia, `Base._similar_for` has different signatures.
 @static if hasmethod(Base._similar_for, Tuple{Array,Type,Any,Base.HasShape})
@@ -224,16 +227,16 @@ Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.HasLength, len::Integ
         QuantityArray(similar(ustrip(c), value_type(T), axes(itr)), dimension(materialize_first(itr))::dim_type(T), T)
 end
 @static if hasmethod(Base._similar_for, Tuple{Array,Type,Any,Base.HasLength})
-    @eval Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.HasLength) where {T} =
-        QuantityArray(similar(ustrip(c), value_type(T), Int(length(itr)::Integer)), dimension(materialize_first(itr))::dim_type(T), T)
+    @eval Base._similar_for(::QuantityArray, ::Type{T}, _, ::Base.HasLength) where {T} =
+        error("Not implemented. Please raise an issue on DynamicQuantities.jl.")
 end
 @static if hasmethod(Base._similar_for, Tuple{Array,Type,Any,Base.SizeUnknown})
-    @eval Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.SizeUnknown) where {T} =
-        QuantityArray(similar(ustrip(c), value_type(T), 0), dimension(materialize_first(itr))::dim_type(T), T)
+    @eval Base._similar_for(::QuantityArray, ::Type{T}, _, ::Base.SizeUnknown) where {T} =
+        error("Not implemented. Please raise an issue on DynamicQuantities.jl.")
 end
 @static if hasmethod(Base._similar_for, Tuple{Array,Type,Any,Any})
-    @eval Base._similar_for(c::QuantityArray, ::Type{T}, itr, isz) where {T} =
-        QuantityArray(similar(ustrip(c), value_type(T)), dimension(materialize_first(itr))::dim_type(T), T)
+    @eval Base._similar_for(::QuantityArray, ::Type{T}, _, _) where {T} =
+        error("Not implemented. Please raise an issue on DynamicQuantities.jl.")
 end
 
 Base.BroadcastStyle(::Type{QA}) where {QA<:QuantityArray} = Broadcast.ArrayStyle{QA}()

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -90,14 +90,14 @@ function Base.convert(::Type{QA}, A::QA) where {QA<:QuantityArray}
     return A
 end
 function Base.convert(::Type{QA1}, A::QA2) where {QA1<:QuantityArray,QA2<:QuantityArray}
+    Q1 = quantity_type(QA1)
+    Q2 = quantity_type(QA2)
+    T = value_type(QA1)
     V = array_type(QA1)
-    D = dim_type(QA1)
-    Q = quantity_type(QA1)
 
     return QuantityArray(
         convert(V, ustrip(A)),
-        convert(D, dimension(A)),
-        Q,
+        convert(Q1, new_quantity(Q2, one(T), dimension(A))),
     )::QA1
 end
 

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -166,6 +166,24 @@ Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.SizeUnknown, ::Nothin
 Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.HasLength, len::Integer) where {T} =
     QuantityArray(similar(ustrip(c), value_type(T), len), dimension(materialize_first(itr))::dim_type(T), T)
 
+# In earlier Julia, `Base._similar_for` has different signatures.
+@static if hasmethod(Base._similar_for, Tuple{Array,Type,Any,Base.HasShape})
+    @eval Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.HasShape) where {T} =
+        QuantityArray(similar(ustrip(c), value_type(T), axes(itr)), dimension(materialize_first(itr))::dim_type(T), T)
+end
+@static if hasmethod(Base._similar_for, Tuple{Array,Type,Any,Base.HasLength})
+    @eval Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.HasLength) where {T} =
+        QuantityArray(similar(ustrip(c), value_type(T), Int(length(itr)::Integer)), dimension(materialize_first(itr))::dim_type(T), T)
+end
+@static if hasmethod(Base._similar_for, Tuple{Array,Type,Any,Base.SizeUnknown})
+    @eval Base._similar_for(c::QuantityArray, ::Type{T}, itr, ::Base.SizeUnknown) where {T} =
+        QuantityArray(similar(ustrip(c), value_type(T), 0), dimension(materialize_first(itr))::dim_type(T), T)
+end
+@static if hasmethod(Base._similar_for, Tuple{Array,Type,Any,Any})
+    @eval Base._similar_for(c::QuantityArray, ::Type{T}, itr, isz) where {T} =
+        QuantityArray(similar(ustrip(c), value_type(T)), dimension(materialize_first(itr))::dim_type(T), T)
+end
+
 Base.BroadcastStyle(::Type{QA}) where {QA<:QuantityArray} = Broadcast.ArrayStyle{QA}()
 
 function Base.similar(bc::Broadcast.Broadcasted{Broadcast.ArrayStyle{QA}}, ::Type{ElType}) where {QA<:QuantityArray,ElType<:UnionAbstractQuantity}

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -180,8 +180,9 @@ end
 for f in (:append!, :prepend!)
     @eval begin
         function Base.$(f)(A::QuantityArray, B::QuantityArray)
-            dimension(A) == dimension(B) || throw(DimensionError(A, B))
-            $(f)(ustrip(A), ustrip(B))
+            B2 = convert(typeof(A), B)
+            dimension(A) == dimension(B2) || throw(DimensionError(A, B))
+            $(f)(ustrip(A), ustrip(B2))
             A
         end
         function Base.$(f)(A::QuantityArray, B::Vector{<:UnionAbstractQuantity})

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -134,7 +134,7 @@ function Base.setindex!(A::QuantityArray{T,N,D,Q}, v::Q, i...) where {T,N,D,Q<:U
     dimension(A) == dimension(v) || throw(DimensionError(A, v))
     return unsafe_setindex!(A, v, i...)
 end
-function Base.setindex!(A::QuantityArray{T,N,D,Q}, v, i...) where {T,N,D,Q<:UnionAbstractQuantity}
+function Base.setindex!(A::QuantityArray{T,N,D,Q}, v::UnionAbstractQuantity, i...) where {T,N,D,Q<:UnionAbstractQuantity}
     return setindex!(A, convert(Q, v)::Q, i...)
 end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1338,6 +1338,17 @@ end
             @test DynamicQuantities.materialize_first(ref) === x[1]
         end
     end
+
+    @testset "Unimplemented methods" begin
+        qa = QuantityArray(randn(3), u"km/s")
+        @test_throws ErrorException Base._similar_for(copy(qa), typeof(u"km/s"), qa, Base.SizeUnknown(), nothing)
+        @test_throws ErrorException Base._similar_for(copy(qa), typeof(u"km/s"), qa, Base.HasLength(), 1)
+        if hasmethod(Base._similar_for, Tuple{Array,Type,Any,Base.HasShape})
+            @test_throws ErrorException Base._similar_for(copy(qa), typeof(u"km/s"), qa, Base.HasLength())
+            @test_throws ErrorException Base._similar_for(copy(qa), typeof(u"km/s"), qa, Base.SizeUnknown())
+            @test_throws ErrorException Base._similar_for(copy(qa), typeof(u"km/s"), qa, 1)
+        end
+    end
 end
 
 @testset "GenericQuantity" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1175,6 +1175,18 @@ end
             @test arr[end] == 6u"m"
             @test_throws DimensionError append!(arr, [7u"s", 8u"s"])
 
+            # Can also append a QuantityArray of symbolic units:
+            arr = QuantityArray([1u"m", 2u"m", 3u"m"])
+            orig_type = typeof(arr)
+            append!(arr, QuantityArray([5us"cm", 6us"cm"]))
+            @test ustrip(arr[end]) == ustrip(6u"cm")
+            @test typeof(arr) === orig_type
+
+            # Or, regular units to symbolic units:
+            arr = QuantityArray([1us"m", 2us"m", 3us"m"])
+            append!(arr, [5u"m", 6u"m"])
+            @test dimension(5us"m") == dimension(arr[end-1])
+
             # Test for prepend!
             arr = QuantityArray([1u"m", 2u"m", 3u"m"])
             prepend!(arr, QuantityArray([-1u"m", -2u"m"]))


### PR DESCRIPTION
Fixes #93 #94 by @jkrumbiegel.

All it turned out to be was a missing method

```julia
Base.similar(::QuantityArray, ::Type{<:Quantity}, ::Dims)
```

which is used in the standard lib for some of the array operations.

The method I had written had mistakenly assumed the `::Type` here was the numeric eltype, like `Float64`. But in retrospect it was perhaps obvious that this would be the quantity type, because, after all, `QuantityArray` is an `AbstractArray{Q,N}` where `Q` is a quantity type.

Let me know if this works for you @jkrumbiegel 

---

I also added a `::Q` type assertion to prevent stack overflows related to converting a quantity of a quantity to a quantity.

We should probably implement a constructor for quantities of quantities that throws an error or simply converts to a regular quantity...