### PR TITLE
More units

### DIFF
--- a/src/units.jl
+++ b/src/units.jl
@@ -187,10 +187,10 @@ end
 ## Pressure
 @register_unit bar 100 * kPa
 
-@add_prefixes bar ()
+@add_prefixes bar (m,)
 
 @doc(
-    "Pressure in bars.",
+    "Pressure in bars. Available variants: `mbar`.",
     bar,
 )
 

--- a/src/units.jl
+++ b/src/units.jl
@@ -177,10 +177,10 @@ end
 ## Volume
 @register_unit L dm^3
 
-@add_prefixes L (m, d)
+@add_prefixes L (m, c, d)
 
 @doc(
-    "Volume in liters. Available variants: `mL`, `dL`.",
+    "Volume in liters. Available variants: `mL`, `cL`, `dL`.",
     L,
 )
 


### PR DESCRIPTION
I'd argue that `mbar` is also a quite common unit. At least much more than `dL`. And because I also think that `cL` is at least as common as `dL` that should be added as well.
Feel free to cherry-pick.