### PR TITLE
Improve `@u_str` implementation to fix downstream precompilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ julia> room_temp = 100kPa
 100000.0 m⁻¹ kg s⁻²
 ```
 
+Note that `Units` is an exported submodule, so you can
+also access this as `Units.kPa`.
+
 This supports a wide range of SI base and derived units, with common
 prefixes.
 
@@ -176,6 +179,12 @@ julia> u"Constants.c * Hz"
 2.99792458e8 m s⁻²
 ```
 
+Similarly, you can just import these:
+
+```julia
+julia> using DynamicQuantities.Constants: c
+```
+
 For the full list, see the [docs](https://symbolicml.org/DynamicQuantities.jl/dev/constants/).
 
 
@@ -219,6 +228,23 @@ You can also convert a quantity in regular base SI units to symbolic units with 
 julia> uconvert(us"nm", 5e-9u"m") # can also write 5e-9u"m" |> uconvert(us"nm")
 5.0 nm
 ```
+
+Finally, you can also import these directly:
+
+```julia
+julia> using DynamicQuantities.SymbolicUnits: cm
+```
+
+or constants:
+
+```julia
+julia> using DynamicQuantities.SymbolicConstants: h
+```
+
+Note that `SymbolicUnits` and `SymbolicConstants` are exported,
+so you can simply access these as `SymbolicUnits.cm` and `SymbolicConstants.h`,
+respectively.
+
 
 ### Arrays
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@ julia> room_temp = 100kPa
 ```
 
 Note that `Units` is an exported submodule, so you can
-also access this as `Units.kPa`.
+also access this as `Units.kPa`. You may like to define
+
+```julia
+julia> const U = Units; const C = Constants;
+```
+
+so that you can simply write, say, `U.kPa` or `C.m_e`.
 
 This supports a wide range of SI base and derived units, with common
 prefixes.
@@ -243,20 +249,7 @@ julia> using DynamicQuantities.SymbolicConstants: h
 
 Note that `SymbolicUnits` and `SymbolicConstants` are exported,
 so you can simply access these as `SymbolicUnits.cm` and `SymbolicConstants.h`,
-respectively. I like to work with these like so:
-
-```julia
-julia> const u = DynamicQuantities.SymbolicUnits;
-
-julia> const C = DynamicQuantities.SymbolicConstants;
-```
-
-so that I can simply write things like:
-
-```julia
-julia> u.yr * C.c |> uexpand |> uconvert(u.km)
-```
-
+respectively.
 
 ### Arrays
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,19 @@ julia> using DynamicQuantities.SymbolicConstants: h
 
 Note that `SymbolicUnits` and `SymbolicConstants` are exported,
 so you can simply access these as `SymbolicUnits.cm` and `SymbolicConstants.h`,
-respectively.
+respectively. I like to work with these like so:
+
+```julia
+julia> const u = DynamicQuantities.SymbolicUnits;
+
+julia> const C = DynamicQuantities.SymbolicConstants;
+```
+
+so that I can simply write things like:
+
+```julia
+julia> u.yr * C.c |> uexpand |> uconvert(u.km)
+```
 
 
 ### Arrays

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Note that `Units` is an exported submodule, so you can
 also access this as `Units.kPa`. You may like to define
 
 ```julia
-julia> const U = Units; const C = Constants;
+julia> const U = Units
 ```
 
 so that you can simply write, say, `U.kPa` or `C.m_e`.
@@ -178,6 +178,12 @@ julia> Constants.c
 2.99792458e8 m s⁻¹
 ```
 
+which you may like to define as
+
+```julia
+julia> const C = Constants
+```
+
 These can also be used inside the `u"..."` macro:
 
 ```julia
@@ -185,10 +191,10 @@ julia> u"Constants.c * Hz"
 2.99792458e8 m s⁻²
 ```
 
-Similarly, you can just import these:
+Similarly, you can just import each individual constant:
 
 ```julia
-julia> using DynamicQuantities.Constants: c
+julia> using DynamicQuantities.Constants: h
 ```
 
 For the full list, see the [docs](https://symbolicml.org/DynamicQuantities.jl/dev/constants/).

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -27,7 +27,7 @@ SymbolicDimensions
 
 Just note that all of the symbolic units and constants are stored using the
 immutable `SymbolicDimensionsSingleton`, which shares the same
-supertype `AbstractSymbolicDimensions <: SymbolicDimensions`. These get immediately
+supertype `AbstractSymbolicDimensions <: AbstractDimensions`. These get immediately
 converted to the mutable `SymbolicDimensions` when used in any
 calculation.
 

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -25,6 +25,17 @@ Another type which subtypes `AbstractDimensions` is `SymbolicDimensions`:
 SymbolicDimensions
 ```
 
+Just note that all of the symbolic units and constants are stored using the
+immutable `SymbolicDimensionsSingleton`, which shares the same
+supertype `AbstractSymbolicDimensions <: SymbolicDimensions`. These get immediately
+converted to the mutable `SymbolicDimensions` when used in any
+calculation.
+
+```@docs
+SymbolicDimensionsSingleton
+AbstractSymbolicDimensions
+```
+
 ## Arrays
 
 ```@docs

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -40,6 +40,19 @@ which is subtyped to `Any`.
 ```@docs
 GenericQuantity
 AbstractGenericQuantity
+```
+
+In the other direction, there is also `RealQuantity`,
+which is subtyped to `Real`.
+
+```@docs
+RealQuantity
+AbstractRealQuantity
+```
+
+More general, these are each contained in the following:
+
+```@docs
 UnionAbstractQuantity
 DynamicQuantities.ABSTRACT_QUANTITY_TYPES
 ```

--- a/ext/DynamicQuantitiesUnitfulExt.jl
+++ b/ext/DynamicQuantitiesUnitfulExt.jl
@@ -30,7 +30,7 @@ for (_, _, Q) in ABSTRACT_QUANTITY_TYPES
             validate_upreferred()
             cumulator = DynamicQuantities.ustrip(x)
             dims = DynamicQuantities.dimension(x)
-            if dims isa DynamicQuantities.SymbolicDimensions
+            if dims isa DynamicQuantities.AbstractSymbolicDimensions
                 throw(ArgumentError("Conversion of a `DynamicQuantities." * string($Q) * "` to a `Unitful.Quantity` is not defined with dimensions of type `SymbolicDimensions`. Instead, you can first use the `uexpand` function to convert the dimensions to their base SI form of type `Dimensions`, then convert this quantity to a `Unitful.Quantity`."))
             end
             equiv = unitful_equivalences()

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -1,9 +1,10 @@
 module DynamicQuantities
 
 export Units, Constants, SymbolicUnits, SymbolicConstants
-export AbstractDimensions, AbstractQuantity, AbstractGenericQuantity, AbstractRealQuantity, UnionAbstractQuantity
+export AbstractQuantity, AbstractGenericQuantity, AbstractRealQuantity, UnionAbstractQuantity
 export Quantity, GenericQuantity, RealQuantity
-export Dimensions, SymbolicDimensions, SymbolicDimensionsSingleton, NoDims
+export AbstractDimensions, Dimensions, NoDims
+export AbstractSymbolicDimensions, SymbolicDimensions, SymbolicDimensionsSingleton
 export QuantityArray
 export DimensionError
 export ustrip, dimension

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -2,7 +2,10 @@ module DynamicQuantities
 
 export Units, Constants, SymbolicUnits, SymbolicConstants
 export AbstractDimensions, AbstractQuantity, AbstractGenericQuantity, AbstractRealQuantity, UnionAbstractQuantity
-export Quantity, GenericQuantity, RealQuantity, Dimensions, SymbolicDimensions, QuantityArray, DimensionError
+export Quantity, GenericQuantity, RealQuantity
+export Dimensions, SymbolicDimensions, SymbolicDimensionsSingleton, NoDims
+export QuantityArray
+export DimensionError
 export ustrip, dimension
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
 export uparse, @u_str, sym_uparse, @us_str, uexpand, uconvert

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -99,15 +99,16 @@ dimension_names(::Type{<:AbstractSymbolicDimensions}) = ALL_SYMBOLS
 Base.propertynames(::AbstractSymbolicDimensions) = ALL_SYMBOLS
 Base.getindex(d::AbstractSymbolicDimensions, k::Symbol) = getproperty(d, k)
 constructorof(::Type{<:SymbolicDimensions}) = SymbolicDimensions
-constructorof(::Type{<:SymbolicDimensionsSingleton{R}}) where {R} = SymbolicDimensionsSingleton{R}
+constructorof(::Type{<:SymbolicDimensionsSingleton}) = SymbolicDimensionsSingleton
 with_type_parameters(::Type{<:SymbolicDimensions}, ::Type{R}) where {R} = SymbolicDimensions{R}
 with_type_parameters(::Type{<:SymbolicDimensionsSingleton}, ::Type{R}) where {R} = SymbolicDimensionsSingleton{R}
 nzdims(d::SymbolicDimensions) = getfield(d, :nzdims)
 nzdims(d::SymbolicDimensionsSingleton) = (getfield(d, :dim),)
 nzvals(d::SymbolicDimensions) = getfield(d, :nzvals)
 nzvals(::SymbolicDimensionsSingleton{R}) where {R} = (one(R),)
-Base.eltype(::AbstractSymbolicDimensions{R}) where {R} = R
-Base.eltype(::Type{<:AbstractSymbolicDimensions{R}}) where {R} = R
+
+# Need to construct with `R` if available, as can't figure it out otherwise:
+constructorof(::Type{<:SymbolicDimensionsSingleton{R}}) where {R} = SymbolicDimensionsSingleton{R}
 
 # Conversion:
 function SymbolicDimensions(d::SymbolicDimensionsSingleton{R}) where {R}
@@ -197,7 +198,7 @@ a function equivalent to `q -> uconvert(qout, q)`.
 uconvert(qout::UnionAbstractQuantity{<:Any,<:AbstractSymbolicDimensions}) = Base.Fix1(uconvert, qout)
 
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(nzdims(d)), copy(nzvals(d)))
-Base.copy(d::SymbolicDimensionsSingleton) = constructorof(d)(getfield(d, :dim))
+Base.copy(d::SymbolicDimensionsSingleton) = constructorof(typeof(d))(getfield(d, :dim))
 
 function Base.:(==)(l::AbstractSymbolicDimensions, r::AbstractSymbolicDimensions)
     nzdims_l = nzdims(l)

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -437,11 +437,11 @@ module SymbolicUnits
     end
     function lookup_unit(ex::Symbol)
         i = findfirst(==(ex), UNIT_SYMBOLS)::Int
-        return SYMBOLIC_UNIT_VALUES[i]
+        return as_quantity(SYMBOLIC_UNIT_VALUES[i])
     end
     function lookup_constant(ex::Symbol)
         i = findfirst(==(ex), CONSTANT_SYMBOLS)::Int
-        return SYMBOLIC_CONSTANT_VALUES[i]
+        return as_quantity(SYMBOLIC_CONSTANT_VALUES[i])
     end
 end
 

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -414,14 +414,11 @@ module SymbolicUnits
         if ex.head == :call
             ex.args[2:end] = map(map_to_scope, ex.args[2:end])
             return ex
-        elseif ex.head == :tuple
-            ex.args[:] = map(map_to_scope, ex.args)
-            return ex
         elseif ex.head == :. && ex.args[1] == :Constants
             @assert ex.args[2] isa QuoteNode
             return lookup_constant(ex.args[2].value)
         else
-            throw(ArgumentError("Unexpected expression: $ex. Only `:call`, `:tuple`, and `:.` (for `SymbolicConstants`) are expected."))
+            throw(ArgumentError("Unexpected expression: $ex. Only `:call` and `:.` (for `SymbolicConstants`) are expected."))
         end
     end
     function map_to_scope(sym::Symbol)

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -400,9 +400,10 @@ module SymbolicUnits
     `Quantity(1.0, SymbolicDimensions, c=2, Hz=2)`. However, note that due to
     namespace collisions, a few physical constants are automatically converted.
     """
-    function sym_uparse(raw_string::AbstractString)
-        raw_result = eval(map_to_scope(Meta.parse(raw_string)))
-        return copy(as_quantity(raw_result))::DEFAULT_SYMBOLIC_QUANTITY_OUTPUT_TYPE
+    function sym_uparse(s::AbstractString)
+        ex = map_to_scope(Meta.parse(s))
+        ex = :($as_quantity($ex))
+        return copy(eval(ex))::DEFAULT_SYMBOLIC_QUANTITY_OUTPUT_TYPE
     end
 
     as_quantity(q::DEFAULT_SYMBOLIC_QUANTITY_OUTPUT_TYPE) = q
@@ -445,9 +446,7 @@ module SymbolicUnits
     end
 end
 
-import .SymbolicUnits: sym_uparse
-import .SymbolicUnits: SymbolicConstants
-import .SymbolicUnits: map_to_scope
+import .SymbolicUnits: as_quantity, sym_uparse, SymbolicConstants, map_to_scope
 
 """
     us"[unit expression]"
@@ -465,8 +464,9 @@ module. So, for example, `us"Constants.c^2 * Hz^2"` would evaluate to
 namespace collisions, a few physical constants are automatically converted.
 """
 macro us_str(s)
-    ex = Meta.parse(s)
-    return esc(map_to_scope(ex))
+    ex = map_to_scope(Meta.parse(s))
+    ex = :($as_quantity($ex))
+    return esc(ex)
 end
 
 function Base.promote_rule(::Type{SymbolicDimensionsSingleton{R1}}, ::Type{SymbolicDimensionsSingleton{R2}}) where {R1,R2}

--- a/src/types.jl
+++ b/src/types.jl
@@ -123,6 +123,20 @@ end
 const DEFAULT_DIM_TYPE = Dimensions{DEFAULT_DIM_BASE_TYPE}
 
 """
+    NoDims{R}
+
+A type representing the dimensions of a non-quantity.
+
+For any `getproperty` call on this type, the result is `zero(R)`.
+"""
+struct NoDims{R<:Real} <: AbstractDimensions{R}
+end
+
+Base.getproperty(::NoDims{R}, ::Symbol) where {R} = zero(R)
+
+const DEFAULT_DIMENSIONLESS_TYPE = NoDims{DEFAULT_DIM_BASE_TYPE}
+
+"""
     Quantity{T<:Number,D<:AbstractDimensions} <: AbstractQuantity{T,D} <: Number
 
 Physical quantity with value `value` of type `T` and dimensions `dimensions` of type `D`.

--- a/src/uparse.jl
+++ b/src/uparse.jl
@@ -66,14 +66,11 @@ function map_to_scope(ex::Expr)
     if ex.head == :call
         ex.args[2:end] = map(map_to_scope, ex.args[2:end])
         return ex
-    elseif ex.head == :tuple
-        ex.args[:] = map(map_to_scope, ex.args)
-        return ex
     elseif ex.head == :. && ex.args[1] == :Constants
         @assert ex.args[2] isa QuoteNode
         return lookup_constant(ex.args[2].value)
     else
-        throw(ArgumentError("Unexpected expression: $ex. Only `:call`, `:tuple`, and `:.` (for `Constants`) are expected."))
+        throw(ArgumentError("Unexpected expression: $ex. Only `:call` and `:.` (for `Constants`) are expected."))
     end
 end
 function map_to_scope(sym::Symbol)

--- a/src/uparse.jl
+++ b/src/uparse.jl
@@ -54,7 +54,7 @@ the quantity corresponding to the speed of light multiplied by Hertz,
 squared.
 """
 macro u_str(s)
-    return esc(uparse(s))
+    return esc(Meta.parse(s))
 end
 
 end

--- a/src/uparse.jl
+++ b/src/uparse.jl
@@ -4,7 +4,8 @@ import ..constructorof
 import ..DEFAULT_QUANTITY_TYPE
 import ..DEFAULT_DIM_TYPE
 import ..DEFAULT_VALUE_TYPE
-import ..Units: UNIT_SYMBOLS
+import ..Units: UNIT_SYMBOLS, UNIT_VALUES
+import ..Constants: CONSTANT_SYMBOLS, CONSTANT_VALUES
 import ..Constants
 
 function _generate_units_import()
@@ -34,11 +35,11 @@ the quantity corresponding to the speed of light multiplied by Hertz,
 squared.
 """
 function uparse(s::AbstractString)
-    return as_quantity(eval(Meta.parse(s)))::DEFAULT_QUANTITY_TYPE
+    return as_quantity(eval(map_to_scope(Meta.parse(s))))::DEFAULT_QUANTITY_TYPE
 end
 
 as_quantity(q::DEFAULT_QUANTITY_TYPE) = q
-as_quantity(x::Number) = convert(DEFAULT_QUANTITY_TYPE,  x)
+as_quantity(x::Number) = convert(DEFAULT_QUANTITY_TYPE, x)
 as_quantity(x) = error("Unexpected type evaluated: $(typeof(x))")
 
 """
@@ -54,7 +55,50 @@ the quantity corresponding to the speed of light multiplied by Hertz,
 squared.
 """
 macro u_str(s)
-    return esc(Meta.parse(s))
+    ex = Meta.parse(s)
+    return esc(map_to_scope(ex))
+end
+
+function map_to_scope(ex::Expr)
+    if ex.head == :call
+        ex.args[2:end] = map(map_to_scope, ex.args[2:end])
+        return ex
+    elseif ex.head == :tuple
+        ex.args[:] = map(map_to_scope, ex.args)
+        return ex
+    elseif ex.head == :.
+        if ex.args[1] == :Constants
+            @assert ex.args[2] isa QuoteNode
+            return lookup_constant(ex.args[2].value)
+        else
+            return ex
+        end
+    else
+        throw(ArgumentError("Unexpected expression: $ex. Only `:call`, `:tuple`, and `:.` are expected."))
+        return ex
+    end
+end
+function map_to_scope(sym::Symbol)
+    if sym in UNIT_SYMBOLS
+        return lookup_unit(sym)
+    elseif sym in CONSTANT_SYMBOLS
+        throw(ArgumentError("Found the symbol $sym. To access constants in a unit expression, access the `Constants` module. For example, `u\"Constants.h\"`."))
+        return sym
+    else
+        throw(ArgumentError("Symbol $sym not found in `Units` or `Constants`."))
+        return sym
+    end
+end
+function map_to_scope(ex)
+    return ex
+end
+function lookup_unit(ex::Symbol)
+    i = findfirst(==(ex), UNIT_SYMBOLS)::Int
+    return UNIT_VALUES[i]
+end
+function lookup_constant(ex::Symbol)
+    i = findfirst(==(ex), CONSTANT_SYMBOLS)::Int
+    return CONSTANT_VALUES[i]
 end
 
 end

--- a/src/uparse.jl
+++ b/src/uparse.jl
@@ -82,7 +82,7 @@ function map_to_scope(sym::Symbol)
     if sym in UNIT_SYMBOLS
         return lookup_unit(sym)
     elseif sym in CONSTANT_SYMBOLS
-        throw(ArgumentError("Found the symbol $sym. To access constants in a unit expression, access the `Constants` module. For example, `u\"Constants.h\"`."))
+        throw(ArgumentError("Symbol $sym found in `Constants` but not `Units`. Please access the `Constants` module. For example, `u\"Constants.$sym\"`."))
         return sym
     else
         throw(ArgumentError("Symbol $sym not found in `Units` or `Constants`."))

--- a/src/uparse.jl
+++ b/src/uparse.jl
@@ -35,7 +35,9 @@ the quantity corresponding to the speed of light multiplied by Hertz,
 squared.
 """
 function uparse(s::AbstractString)
-    return as_quantity(eval(map_to_scope(Meta.parse(s))))::DEFAULT_QUANTITY_TYPE
+    ex = map_to_scope(Meta.parse(s))
+    ex = :($as_quantity($ex))
+    return eval(ex)::DEFAULT_QUANTITY_TYPE
 end
 
 as_quantity(q::DEFAULT_QUANTITY_TYPE) = q
@@ -55,8 +57,9 @@ the quantity corresponding to the speed of light multiplied by Hertz,
 squared.
 """
 macro u_str(s)
-    ex = Meta.parse(s)
-    return esc(map_to_scope(ex))
+    ex = map_to_scope(Meta.parse(s))
+    ex = :($as_quantity($ex))
+    return esc(ex)
 end
 
 function map_to_scope(ex::Expr)

--- a/src/uparse.jl
+++ b/src/uparse.jl
@@ -66,16 +66,11 @@ function map_to_scope(ex::Expr)
     elseif ex.head == :tuple
         ex.args[:] = map(map_to_scope, ex.args)
         return ex
-    elseif ex.head == :.
-        if ex.args[1] == :Constants
-            @assert ex.args[2] isa QuoteNode
-            return lookup_constant(ex.args[2].value)
-        else
-            return ex
-        end
+    elseif ex.head == :. && ex.args[1] == :Constants
+        @assert ex.args[2] isa QuoteNode
+        return lookup_constant(ex.args[2].value)
     else
-        throw(ArgumentError("Unexpected expression: $ex. Only `:call`, `:tuple`, and `:.` are expected."))
-        return ex
+        throw(ArgumentError("Unexpected expression: $ex. Only `:call`, `:tuple`, and `:.` (for `Constants`) are expected."))
     end
 end
 function map_to_scope(sym::Symbol)
@@ -83,10 +78,8 @@ function map_to_scope(sym::Symbol)
         return lookup_unit(sym)
     elseif sym in CONSTANT_SYMBOLS
         throw(ArgumentError("Symbol $sym found in `Constants` but not `Units`. Please access the `Constants` module. For example, `u\"Constants.$sym\"`."))
-        return sym
     else
         throw(ArgumentError("Symbol $sym not found in `Units` or `Constants`."))
-        return sym
     end
 end
 function map_to_scope(ex)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -28,6 +28,13 @@ end
 function Base.promote_rule(::Type{Dimensions{R1}}, ::Type{Dimensions{R2}}) where {R1,R2}
     return Dimensions{promote_type(R1,R2)}
 end
+function Base.promote_rule(::Type{NoDims{R1}}, ::Type{NoDims{R2}}) where {R1,R2}
+    return NoDims{promote_type(R1,R2)}
+end
+function Base.promote_rule(::Type{NoDims{R1}}, ::Type{D}) where {R1,R2,D<:AbstractDimensions{R2}}
+    # The `R1` type is "unused" so we ignore it
+    return D
+end
 
 # Define all the quantity x quantity promotion rules
 """
@@ -340,12 +347,14 @@ ustrip(::AbstractDimensions) = error("Cannot remove units from an `AbstractDimen
 """
     dimension(q::AbstractQuantity)
     dimension(q::AbstractGenericQuantity)
+    dimension(x)
 
 Get the dimensions of a quantity, returning an `AbstractDimensions` object.
 """
 dimension(q::UnionAbstractQuantity) = q.dimensions
 dimension(d::AbstractDimensions) = d
 dimension(aq::AbstractArray{<:UnionAbstractQuantity}) = allequal(dimension.(aq)) ? dimension(first(aq)) : throw(DimensionError(aq[begin], aq[begin+1:end]))
+dimension(_) = DEFAULT_DIMENSIONLESS_TYPE()
 
 """
     ulength(q::AbstractQuantity)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -254,6 +254,7 @@ for f in (
     @eval Base.$f(q::UnionAbstractQuantity) = $f(ustrip(q))
 end
 Base.iszero(d::AbstractDimensions) = all_dimensions(iszero, d)
+Base.iszero(::NoDims) = true
 Base.:(==)(l::AbstractDimensions, r::AbstractDimensions) = all_dimensions(==, l, r)
 
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -480,7 +480,7 @@ end
     VERSION >= v"1.9" && @test_throws "Unexpected expression" uparse("import ..Units")
     @test_throws LoadError eval(:(us"x"))
     VERSION >= v"1.9" && @test_throws "Symbol x not found" sym_uparse("x")
-    VERSION >= v"1.9" && @test_throws "Symbol c found in `Constants` but not `Units`" sym_uparse("c")
+    VERSION >= v"1.9" && @test_throws "Symbol c found in `SymbolicConstants` but not `SymbolicUnits`" sym_uparse("c")
     VERSION >= v"1.9" && @test_throws "Unexpected expression" sym_uparse("import ..Units")
 end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1,5 +1,5 @@
 using DynamicQuantities
-using DynamicQuantities: FixedRational
+using DynamicQuantities: FixedRational, NoDims
 using DynamicQuantities: DEFAULT_QUANTITY_TYPE, DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
 using DynamicQuantities: array_type, value_type, dim_type, quantity_type
 using DynamicQuantities: GenericQuantity, with_type_parameters, constructorof
@@ -1633,6 +1633,18 @@ end
         @eval @test all($f.($qx_real_dimensions, $qy_dimensions) .== $ground_truth)
         @eval @test all($f.($qx_dimensions, $qy_real_dimensions) .== $ground_truth)
     end
+
+    # Should be able to compare against `NoDims`:
+    @test Quantity(1.0) >= 1.0
+    @test !(Quantity(1.0) > 1.0)
+end
+
+@testset "Extra tests of `NoDims`" begin
+    @test promote_type(NoDims{Int16}, NoDims{Int32}) === NoDims{Int32}
+
+    # Prefer other types, always:
+    @test promote_type(Dimensions{Int16}, NoDims{Int32}) === Dimensions{Int16}
+    @test promote_type(MyDimensions{Int16}, NoDims{Int32}) === MyDimensions{Int16}
 end
 
 @testset "Test div" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1681,6 +1681,7 @@ end
 
 @testset "Tests of SymbolicDimensionsSingleton" begin
     km = SymbolicUnits.km
+    m = SymbolicUnits.m
     @test km isa Quantity{T,SymbolicDimensionsSingleton{R}} where {T,R}
     @test dimension(km) isa SymbolicDimensionsSingleton
     @test dimension(km) isa AbstractSymbolicDimensions
@@ -1730,6 +1731,19 @@ end
             SymbolicDimensionsSingleton{Int64},
             Dimensions{Int16}
         ) === Dimensions{Int64}
+
+    # Test map_dimensions explicitly for coverage:
+    @test map_dimensions(-, dimension(km)).km == -1
+    @test map_dimensions(-, dimension(km)) isa SymbolicDimensions
+    @test map_dimensions(+, dimension(km), dimension(m)).km == 1
+    @test map_dimensions(+, dimension(km), dimension(m)).m == 1
+    @test map_dimensions(+, dimension(km), dimension(m)).cm == 0
+    @test map_dimensions(+, dimension(km), SymbolicDimensions(dimension(m))).km == 1
+    @test map_dimensions(+, dimension(km), SymbolicDimensions(dimension(m))).m == 1
+    @test map_dimensions(+, dimension(km), SymbolicDimensions(dimension(m))).cm == 0
+    @test map_dimensions(+, SymbolicDimensions(dimension(km)), dimension(m)).km == 1
+    @test map_dimensions(+, SymbolicDimensions(dimension(km)), dimension(m)).m == 1
+    @test map_dimensions(+, SymbolicDimensions(dimension(km)), dimension(m)).cm == 0
 end
 
 @testset "Test div" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -471,9 +471,13 @@ end
     @test typeof(u"fm") == DEFAULT_QUANTITY_TYPE
     @test typeof(u"fm"^2) == DEFAULT_QUANTITY_TYPE
 
+    # Can also use tuples:
+    @test typeof(u"(m, s)") == Tuple{DEFAULT_QUANTITY_TYPE, DEFAULT_QUANTITY_TYPE}
+
     @test_throws LoadError eval(:(u"x"))
     VERSION >= v"1.9" && @test_throws "Symbol x not found" uparse("x")
     VERSION >= v"1.9" && @test_throws "Symbol c found in `Constants` but not `Units`" uparse("c")
+    VERSION >= v"1.9" && @test_throws "Unexpected expression" uparse("import ..Units")
 end
 
 @testset "Constants" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1689,9 +1689,12 @@ end
     @test dimension(km).m == 0
     VERSION >= v"1.9" &&
         @test_throws "is not available as a symbol" dimension(km).γ
-    @test !iszero(km)
+    @test !iszero(dimension(km))
     @test inv(km) == us"km^-1"
     @test inv(km) == u"km^-1"
+
+    @test !iszero(dimension(SymbolicConstants.c))
+    @test SymbolicConstants.c isa Quantity{T,SymbolicDimensionsSingleton{R}} where {T,R}
 
     # Constructors
     @test SymbolicDimensionsSingleton(:cm) isa SymbolicDimensionsSingleton{DEFAULT_DIM_BASE_TYPE}

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -471,7 +471,9 @@ end
     @test typeof(u"fm") == DEFAULT_QUANTITY_TYPE
     @test typeof(u"fm"^2) == DEFAULT_QUANTITY_TYPE
 
-    @test_throws ArgumentError eval(:(u":x"))
+    @test_throws LoadError eval(:(u"x"))
+    VERSION >= v"1.9" && @test_throws "Symbol x not found" uparse("x")
+    VERSION >= v"1.9" && @test_throws "Symbol c found in `Constants` but not `Units`" uparse("c")
 end
 
 @testset "Constants" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1760,6 +1760,11 @@ end
     @test [km, km] isa Vector{Quantity{T,SymbolicDimensionsSingleton{R}}} where {T,R}
     @test [km^2, km] isa Vector{Quantity{T,SymbolicDimensions{R}}} where {T,R}
 
+    # No issue when converting to SymbolicDimensionsSingleton (gets
+    # converted)
+    @test uconvert(km, u"m") == 0.001km
+    @test uconvert(km, u"m") isa Quantity{T,SymbolicDimensions{R}} where {T,R}
+
     # Symbolic dimensions retain symbols:
     @test QuantityArray([km, km]) |> uconvert(us"m") == [1000m, 1000m]
     @test QuantityArray([km, km]) |> uconvert(us"m") != [km, km]

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -4,6 +4,7 @@ using DynamicQuantities: DEFAULT_QUANTITY_TYPE, DEFAULT_DIM_BASE_TYPE, DEFAULT_D
 using DynamicQuantities: array_type, value_type, dim_type, quantity_type
 using DynamicQuantities: GenericQuantity, with_type_parameters, constructorof
 using DynamicQuantities: promote_quantity_on_quantity, promote_quantity_on_value
+using DynamicQuantities: map_dimensions
 using Ratios: SimpleRatio
 using SaferIntegers: SafeInt16
 using StaticArrays: SArray, MArray
@@ -748,6 +749,14 @@ end
     @test dimension(uexpand(x * y)) == dimension(u"m^9 * s")
     z = uexpand(x)
     @test x == z
+
+    # Trigger part of map_dimensions missed elsewhere
+    x = us"km"
+    y = us"km"
+    @test x * y |> uexpand == u"km^2"
+    @test x / y |> uexpand == u"1"
+    @test map_dimensions(+, dimension(us"km"), dimension(us"km")) == dimension(us"km^2")
+    @test map_dimensions(-, dimension(us"km"), dimension(us"km")) == dimension(us"1")
 
     @testset "Promotion with Dimensions" begin
         x = 0.5u"cm"

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1714,6 +1714,22 @@ end
     
     # Any operation should immediately convert it:
     @test km ^ -1 isa Quantity{T,DynamicQuantities.SymbolicDimensions{R}} where {T,R}
+
+    # Test promotion explicitly for coverage:
+    @test promote_type(
+            SymbolicDimensionsSingleton{Int16},
+            SymbolicDimensionsSingleton{Int32}
+        ) === SymbolicDimensions{Int32}
+    # ^ Note how we ALWAYS convert to SymbolicDimensions, even
+    # if the types are the same.
+    @test promote_type(
+            SymbolicDimensionsSingleton{Int16},
+            SymbolicDimensions{Int32}
+        ) === SymbolicDimensions{Int32}
+    @test promote_type(
+            SymbolicDimensionsSingleton{Int64},
+            Dimensions{Int16}
+        ) === Dimensions{Int64}
 end
 
 @testset "Test div" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -462,26 +462,26 @@ end
     @test utime(z) == 1
     @test ustrip(z) ≈ 60 * 60 * 24 * 365.25
 
-    # Test that `u_str` respects original type:
-    @test typeof(u"1") == Int
-    @test typeof(u"1f0") == Float32
+    # Test type stability of extreme range of units
+    @test typeof(u"1") == DEFAULT_QUANTITY_TYPE
+    @test typeof(u"1f0") == DEFAULT_QUANTITY_TYPE
     @test typeof(u"s"^2) == DEFAULT_QUANTITY_TYPE
     @test typeof(u"Ω") == DEFAULT_QUANTITY_TYPE
     @test typeof(u"Gyr") == DEFAULT_QUANTITY_TYPE
     @test typeof(u"fm") == DEFAULT_QUANTITY_TYPE
     @test typeof(u"fm"^2) == DEFAULT_QUANTITY_TYPE
 
-    # Can also use tuples:
-    @test typeof(u"(m, s)") == Tuple{DEFAULT_QUANTITY_TYPE, DEFAULT_QUANTITY_TYPE}
+    @test_throws ErrorException eval(:(u":x"))
 
-    @test_throws LoadError eval(:(u"x"))
     VERSION >= v"1.9" && @test_throws "Symbol x not found" uparse("x")
     VERSION >= v"1.9" && @test_throws "Symbol c found in `Constants` but not `Units`" uparse("c")
     VERSION >= v"1.9" && @test_throws "Unexpected expression" uparse("import ..Units")
+    VERSION >= v"1.9" && @test_throws "Unexpected expression" uparse("(m, m)")
     @test_throws LoadError eval(:(us"x"))
     VERSION >= v"1.9" && @test_throws "Symbol x not found" sym_uparse("x")
     VERSION >= v"1.9" && @test_throws "Symbol c found in `SymbolicConstants` but not `SymbolicUnits`" sym_uparse("c")
     VERSION >= v"1.9" && @test_throws "Unexpected expression" sym_uparse("import ..Units")
+    VERSION >= v"1.9" && @test_throws "Unexpected expression" sym_uparse("(m, m)")
 end
 
 @testset "Constants" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1,5 +1,5 @@
 using DynamicQuantities
-using DynamicQuantities: FixedRational, NoDims
+using DynamicQuantities: FixedRational, NoDims, AbstractSymbolicDimensions
 using DynamicQuantities: DEFAULT_QUANTITY_TYPE, DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
 using DynamicQuantities: array_type, value_type, dim_type, quantity_type
 using DynamicQuantities: GenericQuantity, with_type_parameters, constructorof

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1753,6 +1753,16 @@ end
     @test map_dimensions(+, SymbolicDimensions(dimension(km)), dimension(m)).km == 1
     @test map_dimensions(+, SymbolicDimensions(dimension(km)), dimension(m)).m == 1
     @test map_dimensions(+, SymbolicDimensions(dimension(km)), dimension(m)).cm == 0
+
+    # Note that we avoid converting to SymbolicDimensionsSingleton for uconvert:
+    @test km |> uconvert(us"m") == 1000m
+    @test km |> uconvert(us"m") isa Quantity{T,SymbolicDimensions{R}} where {T,R}
+    @test [km, km] isa Vector{Quantity{T,SymbolicDimensionsSingleton{R}}} where {T,R}
+    @test [km^2, km] isa Vector{Quantity{T,SymbolicDimensions{R}}} where {T,R}
+
+    # Symbolic dimensions retain symbols:
+    @test QuantityArray([km, km]) |> uconvert(us"m") == [1000m, 1000m]
+    @test QuantityArray([km, km]) |> uconvert(us"m") != [km, km]
 end
 
 @testset "Test div" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -478,6 +478,10 @@ end
     VERSION >= v"1.9" && @test_throws "Symbol x not found" uparse("x")
     VERSION >= v"1.9" && @test_throws "Symbol c found in `Constants` but not `Units`" uparse("c")
     VERSION >= v"1.9" && @test_throws "Unexpected expression" uparse("import ..Units")
+    @test_throws LoadError eval(:(us"x"))
+    VERSION >= v"1.9" && @test_throws "Symbol x not found" sym_uparse("x")
+    VERSION >= v"1.9" && @test_throws "Symbol c found in `Constants` but not `Units`" sym_uparse("c")
+    VERSION >= v"1.9" && @test_throws "Unexpected expression" sym_uparse("import ..Units")
 end
 
 @testset "Constants" begin

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -462,16 +462,16 @@ end
     @test utime(z) == 1
     @test ustrip(z) ≈ 60 * 60 * 24 * 365.25
 
-    # Test type stability of extreme range of units
-    @test typeof(u"1") == DEFAULT_QUANTITY_TYPE
-    @test typeof(u"1f0") == DEFAULT_QUANTITY_TYPE
+    # Test that `u_str` respects original type:
+    @test typeof(u"1") == Int
+    @test typeof(u"1f0") == Float32
     @test typeof(u"s"^2) == DEFAULT_QUANTITY_TYPE
     @test typeof(u"Ω") == DEFAULT_QUANTITY_TYPE
     @test typeof(u"Gyr") == DEFAULT_QUANTITY_TYPE
     @test typeof(u"fm") == DEFAULT_QUANTITY_TYPE
     @test typeof(u"fm"^2) == DEFAULT_QUANTITY_TYPE
 
-    @test_throws LoadError eval(:(u":x"))
+    @test_throws ArgumentError eval(:(u":x"))
 end
 
 @testset "Constants" begin


### PR DESCRIPTION
Fixes #105 which reported precompilation issues.

- Manual parser for `u_str` to avoid calling `eval` (which breaks precompilation)
  - Also implements for `us_str`
- Creates the `NoDims` type so that `dimension(1.0)` doesn't throw a method error.
- Allows you to use `uconvert` in more contexts, like `SymbolicDimensions` -> `SymbolicDimensions`
