### PR TITLE
Improved Base.isapprox support

### DIFF
--- a/ext/DynamicQuantitiesLinearAlgebraExt.jl
+++ b/ext/DynamicQuantitiesLinearAlgebraExt.jl
@@ -5,4 +5,20 @@ import DynamicQuantities: UnionAbstractQuantity, ustrip, dimension, new_quantity
 
 norm(q::UnionAbstractQuantity, p::Real=2) = new_quantity(typeof(q), norm(ustrip(q), p), dimension(q))
 
+# Define isapprox for vectors of Quantity types
+function Base.isapprox(
+    u::AbstractArray{Q}, v::AbstractArray{Q};
+    atol=new_quantity(Q, zero(T), dimension(first(u))),
+    rtol=Base.rtoldefault(T),
+    nans::Bool=false, norm::Function=norm
+) where {T, D, Q<:UnionAbstractQuantity{T,D}}
+    d = norm(u - v)
+    if isfinite(d)
+        return d <= max(atol, rtol*max(norm(u), norm(v)))
+    else
+        # Fall back to a component-wise approximate comparison
+        return all(ab -> isapprox(uv[1], uv[2]; rtol=rtol, atol=atol, nans=nans), zip(u, v))
+    end
+end
+
 end

--- a/src/math.jl
+++ b/src/math.jl
@@ -191,7 +191,7 @@ end
 ############################## Same dimension as input ##################################
 for f in (
     :float, :abs, :real, :imag, :conj, :adjoint, :unsigned,
-    :nextfloat, :prevfloat, :transpose, :significand
+    :nextfloat, :prevfloat, :transpose, :significand, :rtoldefault
 )
     @eval function Base.$f(q::UnionAbstractQuantity)
         return new_quantity(typeof(q), $f(ustrip(q)), dimension(q))

--- a/src/math.jl
+++ b/src/math.jl
@@ -191,7 +191,7 @@ end
 ############################## Same dimension as input ##################################
 for f in (
     :float, :abs, :real, :imag, :conj, :adjoint, :unsigned,
-    :nextfloat, :prevfloat, :transpose, :significand, :rtoldefault
+    :nextfloat, :prevfloat, :transpose, :significand
 )
     @eval function Base.$f(q::UnionAbstractQuantity)
         return new_quantity(typeof(q), $f(ustrip(q)), dimension(q))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -257,12 +257,11 @@ end
 
 # Define isapprox for vectors
 function Base.isapprox(
-    u::AbstractArray{<:UnionAbstractQuantity{T,D}},
-	v::AbstractArray{<:UnionAbstractQuantity{T,D}};
-    atol=new_quantity(T, zero(T), dimension(first(u))),
+    u::AbstractArray{Q}, v::AbstractArray{Q};
+    atol=new_quantity(Q, zero(T), dimension(first(u))),
     rtol=Base.rtoldefault(ustrip(first(u))),
     nans::Bool=false, norm::Function=norm
-) where {T,D}
+) where {T, D, Q<:UnionAbstractQuantity{T,D}}
     d = norm(u - v)
     if isfinite(d)
         return d <= max(atol, rtol*max(norm(u), norm(v)))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -255,6 +255,23 @@ for (type, true_base_type, _) in ABSTRACT_QUANTITY_TYPES
     end
 end
 
+# Define isapprox for vectors
+function Base.isapprox(
+    u::AbstractArray{<:UnionAbstractQuantity{T,D}},
+	v::AbstractArray{<:UnionAbstractQuantity{T,D}};
+    atol=new_quantity(T, zero(T), dimension(first(u))),
+    rtol=Base.rtoldefault(ustrip(first(u))),
+    nans::Bool=false, norm::Function=norm
+) where {T,D}
+    d = norm(u - v)
+    if isfinite(d)
+        return d <= max(atol, rtol*max(norm(u), norm(v)))
+    else
+        # Fall back to a component-wise approximate comparison
+        return all(ab -> isapprox(uv[1], uv[2]; rtol=rtol, atol=atol, nans=nans), zip(u, v))
+    end
+end
+
 # Simple flags:
 for f in (
     :isone, :iszero, :isfinite, :isinf, :isnan, :isreal, :signbit,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -169,14 +169,15 @@ for (type, _, _) in ABSTRACT_QUANTITY_TYPES
 end
 Base.keys(q::UnionAbstractQuantity) = keys(ustrip(q))
 
-# If atol specified in kwargs, check its dimensions and then strip units
+# If atol specified in kwargs, validate its dimensions and then strip units
 function _strip_kws(dimcheck, kws)
     if :atol in keys(kws)
         dimension(dimcheck) == dimension(kws[:atol]) || throw(DimensionError(dimcheck, kws[:atol]))
-        kws_dict = Dict{Symbol,Any}(kws)
-        kws_dict[:atol] = ustrip(kws_dict[:atol])
+        kws = Dict{Symbol,Any}(kws)
+        kws[:atol] = ustrip(kws[:atol])
     end
-    return kws_dict
+
+    return kws
 end
 
 # Numeric checks
@@ -233,9 +234,7 @@ for (type, true_base_type, _) in ABSTRACT_QUANTITY_TYPES
         function Base.isapprox(l::$type, r::$type; kws...)
             l, r = promote_except_value(l, r)
             dimension(l) == dimension(r) || throw(DimensionError(l, r))
-            new_kws = _strip_kws(l, kws)
-            @info new_kws
-            return isapprox(ustrip(l), ustrip(r); new_kws...)
+            return isapprox(ustrip(l), ustrip(r); _strip_kws(l, kws)...)
         end
         function Base.isapprox(l::$base_type, r::$type; kws...)
             iszero(dimension(r)) || throw(DimensionError(l, r))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -173,11 +173,13 @@ Base.keys(q::UnionAbstractQuantity) = keys(ustrip(q))
 function _strip_kws(dimcheck, kws)
     if :atol in keys(kws)
         dimension(dimcheck) == dimension(kws[:atol]) || throw(DimensionError(dimcheck, kws[:atol]))
-        kws = replace(kws) do kv
+        new_kws = replace(kws) do kv
             first(kv) == :atol ? first(kv)=>ustrip(last(kv)) : kv
         end
     end
-    return kws
+    @info kws
+    @info new_kws
+    return new_kws
 end
 
 # Numeric checks

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -177,8 +177,6 @@ function _strip_kws(dimcheck, kws)
             first(kv) == :atol ? first(kv)=>ustrip(last(kv)) : kv
         end
     end
-    @info kws
-    @info new_kws
     return new_kws
 end
 
@@ -236,7 +234,9 @@ for (type, true_base_type, _) in ABSTRACT_QUANTITY_TYPES
         function Base.isapprox(l::$type, r::$type; kws...)
             l, r = promote_except_value(l, r)
             dimension(l) == dimension(r) || throw(DimensionError(l, r))
-            return isapprox(ustrip(l), ustrip(r); _strip_kws(l, kws)...)
+            new_kws = _strip_kws(l, kws)
+            @info new_kws
+            return isapprox(ustrip(l), ustrip(r); new_kws...)
         end
         function Base.isapprox(l::$base_type, r::$type; kws...)
             iszero(dimension(r)) || throw(DimensionError(l, r))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -173,11 +173,10 @@ Base.keys(q::UnionAbstractQuantity) = keys(ustrip(q))
 function _strip_kws(dimcheck, kws)
     if :atol in keys(kws)
         dimension(dimcheck) == dimension(kws[:atol]) || throw(DimensionError(dimcheck, kws[:atol]))
-        new_kws = replace(kws) do kv
-            first(kv) == :atol ? first(kv)=>ustrip(last(kv)) : kv
-        end
+        kws_dict = Dict{Symbol,Any}(kws)
+        kws_dict[:atol] = ustrip(kws_dict[:atol])
     end
-    return new_kws
+    return kws_dict
 end
 
 # Numeric checks

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -259,7 +259,7 @@ end
 function Base.isapprox(
     u::AbstractArray{Q}, v::AbstractArray{Q};
     atol=new_quantity(Q, zero(T), dimension(first(u))),
-    rtol=Base.rtoldefault(ustrip(first(u))),
+    rtol=Base.rtoldefault(T),
     nans::Bool=false, norm::Function=norm
 ) where {T, D, Q<:UnionAbstractQuantity{T,D}}
     d = norm(u - v)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -255,21 +255,6 @@ for (type, true_base_type, _) in ABSTRACT_QUANTITY_TYPES
     end
 end
 
-# Define isapprox for vectors
-function Base.isapprox(
-    u::AbstractArray{Q}, v::AbstractArray{Q};
-    atol=new_quantity(Q, zero(T), dimension(first(u))),
-    rtol=Base.rtoldefault(T),
-    nans::Bool=false, norm::Function=norm
-) where {T, D, Q<:UnionAbstractQuantity{T,D}}
-    d = norm(u - v)
-    if isfinite(d)
-        return d <= max(atol, rtol*max(norm(u), norm(v)))
-    else
-        # Fall back to a component-wise approximate comparison
-        return all(ab -> isapprox(uv[1], uv[2]; rtol=rtol, atol=atol, nans=nans), zip(u, v))
-    end
-end
 
 # Simple flags:
 for f in (

--- a/test/test_unitful.jl
+++ b/test/test_unitful.jl
@@ -14,14 +14,16 @@ end
 for T in [DEFAULT_VALUE_TYPE, Float16, Float32, Float64], R in [DEFAULT_DIM_BASE_TYPE, Rational{Int16}, Rational{Int32}, SimpleRatio{Int}, SimpleRatio{SafeInt16}]
     D = DynamicQuantities.Dimensions{R}
     x = DynamicQuantities.Quantity(T(0.2), D, length=1, amount=2, current=-1 // 2, luminosity=2 // 5)
+    tol_dq = DynamicQuantities.Quantity(T(1e-6), D, length=1, amount=2, current=-1 // 2, luminosity=2 // 5)
     x_unitful = T(0.2)u"m*mol^2*A^(-1//2)*cd^(2//5)"
+    tol_unitful = T(1e-6)u"m*mol^2*A^(-1//2)*cd^(2//5)"
 
-    @test risapprox(convert(Unitful.Quantity, x), x_unitful; atol=1e-6)
+    @test risapprox(convert(Unitful.Quantity, x), x_unitful; atol=tol_unitful)
     @test typeof(convert(DynamicQuantities.Quantity, convert(Unitful.Quantity, x))) <: DynamicQuantities.Quantity{T,DynamicQuantities.DEFAULT_DIM_TYPE}
-    @test isapprox(convert(DynamicQuantities.Quantity, convert(Unitful.Quantity, x)), x; atol=1e-6)
+    @test isapprox(convert(DynamicQuantities.Quantity, convert(Unitful.Quantity, x)), x; atol=tol_dq)
 
-    @test isapprox(convert(DynamicQuantities.Quantity{T,D}, x_unitful), x; atol=1e-6)
-    @test risapprox(convert(Unitful.Quantity, convert(DynamicQuantities.Quantity{T,D}, x_unitful)), Unitful.upreferred(x_unitful); atol=1e-6)
+    @test isapprox(convert(DynamicQuantities.Quantity{T,D}, x_unitful), x; atol=tol_dq)
+    @test risapprox(convert(Unitful.Quantity, convert(DynamicQuantities.Quantity{T,D}, x_unitful)), Unitful.upreferred(x_unitful); atol=tol_unitful)
 
     @test typeof(convert(DynamicQuantities.Dimensions, Unitful.dimension(x_unitful))) == DynamicQuantities.Dimensions{DEFAULT_DIM_BASE_TYPE}
 end

--- a/test/test_unitful.jl
+++ b/test/test_unitful.jl
@@ -18,12 +18,12 @@ for T in [DEFAULT_VALUE_TYPE, Float16, Float32, Float64], R in [DEFAULT_DIM_BASE
     x_unitful = T(0.2)u"m*mol^2*A^(-1//2)*cd^(2//5)"
     tol_unitful = T(1e-6)u"m*mol^2*A^(-1//2)*cd^(2//5)"
 
-    @test risapprox(convert(Unitful.Quantity, x), x_unitful; atol=tol_unitful)
+    @test risapprox(convert(Unitful.Quantity, x), x_unitful; atol=1e-6)
     @test typeof(convert(DynamicQuantities.Quantity, convert(Unitful.Quantity, x))) <: DynamicQuantities.Quantity{T,DynamicQuantities.DEFAULT_DIM_TYPE}
     @test isapprox(convert(DynamicQuantities.Quantity, convert(Unitful.Quantity, x)), x; atol=tol_dq)
 
     @test isapprox(convert(DynamicQuantities.Quantity{T,D}, x_unitful), x; atol=tol_dq)
-    @test risapprox(convert(Unitful.Quantity, convert(DynamicQuantities.Quantity{T,D}, x_unitful)), Unitful.upreferred(x_unitful); atol=tol_unitful)
+    @test risapprox(convert(Unitful.Quantity, convert(DynamicQuantities.Quantity{T,D}, x_unitful)), Unitful.upreferred(x_unitful); atol=1e-6)
 
     @test typeof(convert(DynamicQuantities.Dimensions, Unitful.dimension(x_unitful))) == DynamicQuantities.Dimensions{DEFAULT_DIM_BASE_TYPE}
 end

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -806,7 +806,7 @@ end
         q = convert(Q{Float16}, 1.5u"g")
         qs = uconvert(convert(Q{Float16}, us"g"), 5 * q)
         @test typeof(qs) <: Q{Float16,<:SymbolicDimensions{<:Any}}
-        @test isapprox(qs, 7.5us"g"; atol=0.01)
+        @test isapprox(qs, 7.5us"g"; atol=0.01us"g")
 
         # Arrays
         x = [1.0, 2.0, 3.0] .* Q(u"kg")


### PR DESCRIPTION
This PR is intended to address concerns discussed in #111, specifically:
- Implements support for dimensionful types in the `atol` keyword argument for `Base.isapprox`
- Adds support for `isapprox(::AbstractVector{Q}, ::AbstractVector{Q})` where `Q` is a Quantity type (in the LinearAlgebra extension)

This would technically be considered a breaking change due to the behavior change for `atol` keyword arguments. Previously, this argument took a `::Real` and treated it as implicitly having the same units as the quantities being compared. As of this update, applicable units must be specified manually. This will make comparisons more explicit and less error prone. Additionally, this will enable comparisons like `isapprox(1.234u"m", 1234.0u"cm"; atol=1.0u"mm")`.