### PR TITLE
Define `|>` as an infix operator for `uconvert`

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,9 +237,10 @@ julia> uexpand(x^2)
 
 You can also convert a quantity in regular base SI units to symbolic units with `uconvert`:
 ```julia
-julia> uconvert(us"nm", 5e-9u"m") # can also write 5e-9u"m" |> uconvert(us"nm")
+julia> uconvert(us"nm", 5e-9u"m") # can also write 5e-9u"m" |> uconvert(us"nm") or 5e-9u"m" |> us"nm"
 5.0 nm
 ```
+
 
 Finally, you can also import these directly:
 

--- a/README.md
+++ b/README.md
@@ -237,9 +237,11 @@ julia> uexpand(x^2)
 
 You can also convert a quantity in regular base SI units to symbolic units with `uconvert`:
 ```julia
-julia> uconvert(us"nm", 5e-9u"m") # can also write 5e-9u"m" |> uconvert(us"nm") or 5e-9u"m" |> us"nm"
+julia> uconvert(us"nm", 5e-9u"m")
 5.0 nm
 ```
+
+We can also simply write this as `5e-9u"m" |> us"nm"`.
 
 
 Finally, you can also import these directly:

--- a/README.md
+++ b/README.md
@@ -235,13 +235,14 @@ julia> uexpand(x^2)
 8.987551787368176e16 m² s⁻⁴
 ```
 
-You can also convert a quantity in regular base SI units to symbolic units with `uconvert`:
+You can also convert a quantity in regular base SI units to symbolic units by using it as a function:
 ```julia
-julia> uconvert(us"nm", 5e-9u"m")
+julia> 5e-9u"m" |> us"nm"
 5.0 nm
 ```
 
-We can also simply write this as `5e-9u"m" |> us"nm"`.
+We can also simply write this more explicitly
+with `uconvert(us"nm", 5e-9u"m")`.
 
 
 Finally, you can also import these directly:

--- a/docs/src/examples.md
+++ b/docs/src/examples.md
@@ -28,7 +28,7 @@ julia> p = sqrt(2 * m_e * (E - Φ)) # momentum of ejected electrons
 julia> λ = h / p # wavelength of ejected electrons
 3.029491247878056e-9 m
 
-julia> uconvert(us"nm", λ) # return answer in nanometers
+julia> λ |> us"nm" # return answer in nanometers (equivalent to `uconvert(us"nm", λ)`)
 3.0294912478780556 nm
 ```
 
@@ -96,8 +96,8 @@ Next, let's plot the trajectory.
 First convert to km and strip units:
 
 ```julia
-x_km = ustrip.(uconvert(us"km").(x_si))
-y_km = ustrip.(uconvert(us"km").(y_si))
+x_km = ustrip.(x_si .|> us"km")
+y_km = ustrip.(y_si .|> us"km")
 ```
 
 Now, we plot:
@@ -284,7 +284,7 @@ coord2 = GenericQuantity(Coords(0.2, -0.1), length=1)
 and perform operations on these:
 
 ```julia
-coord1 + coord2 |> uconvert(us"cm")
+coord1 + coord2 |> us"cm"
 # (Coords(50.0, 80.0)) cm
 ```
 

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -227,11 +227,12 @@ uconvert(qout::UnionAbstractQuantity{<:Any,<:AbstractSymbolicDimensions}) = Base
 
 
 """
-   (qout::UnionAbstractQuantity{<:Any, <:AbstractSymbolicDimensions})(x)
+   (qout::UnionAbstractQuantity{<:Any, <:AbstractSymbolicDimensions})(q)
 
-Make quantities with symbolic units callabele, thus allowing for e.g. ` 15m|> us"km" `
+Quantities with symbolic units are callable, and act as a `uconvert` function with
+the symbolic units of the quantity as the desired output units.
 """
-(qout::UnionAbstractQuantity{<:Any, <:AbstractSymbolicDimensions})(x) = uconvert(qout,x)
+(qout::UnionAbstractQuantity{<:Any, <:AbstractSymbolicDimensions})(q) = uconvert(qout, q)
 
 
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(nzdims(d)), copy(nzvals(d)))

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -238,6 +238,12 @@ a function equivalent to `q -> uconvert(qout, q)`.
 uconvert(qout::UnionAbstractQuantity) = Base.Fix1(uconvert, qout)
 
 
+"""
+    |>(q::Union{UnionAbstractQuantity,QuantityArray,Number}, qout::UnionAbstractQuantity)
+
+
+Using `q |> qout` is an alias for `uconvert(qout, q)`.
+"""
 function Base.:(|>)(
     q::Union{UnionAbstractQuantity,QuantityArray,Number},
     qout::UnionAbstractQuantity

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -225,6 +225,15 @@ a function equivalent to `q -> uconvert(qout, q)`.
 """
 uconvert(qout::UnionAbstractQuantity{<:Any,<:AbstractSymbolicDimensions}) = Base.Fix1(uconvert, qout)
 
+
+"""
+   (qout::UnionAbstractQuantity{<:Any, <:AbstractSymbolicDimensions})(x)
+
+Make quantities with symbolic units callabele, thus allowing for e.g. ` 15m|> us"km" `
+"""
+(qout::UnionAbstractQuantity{<:Any, <:AbstractSymbolicDimensions})(x) = uconvert(qout,x)
+
+
 Base.copy(d::SymbolicDimensions) = SymbolicDimensions(copy(nzdims(d)), copy(nzvals(d)))
 Base.copy(d::SymbolicDimensionsSingleton) = constructorof(typeof(d))(getfield(d, :dim))
 

--- a/src/symbolic_dimensions.jl
+++ b/src/symbolic_dimensions.jl
@@ -225,7 +225,7 @@ end
 function uconvert(::UnionAbstractQuantity{<:Any,<:Dimensions}, _)
     error(
         "You can only `uconvert` to quantities with `SymbolicDimensions` type, not `Dimensions`. "
-        "Try using `us\"km\"` instead of `u\"km\"`."
+        * "Try using `us\"km\"` instead of `u\"km\"`."
     )
 end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -808,7 +808,7 @@ end
         @test_throws "You passed a quantity" uconvert(1.2us"m", 1.0u"m")
 
     # Refuses to convert to `Dimensions`:
-    @test_throws AssertionError uconvert(1u"m", 5.0us"m")
+    @test_throws ErrorException uconvert(1u"m", 5.0us"m")
     VERSION >= v"1.8" &&
         @test_throws "You can only `uconvert`" uconvert(1u"m", 5.0us"m")
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -799,8 +799,9 @@ end
     @test dimension(qs)[:M_sun] == 1
     @test uexpand(qs) ≈ 5.0 * q
 
-    @test uconvert(us"nm",1u"m") == 1u"m" |> us"nm"
-    
+    @test dimension(1u"m" |> us"nm")[:nm] == 1
+    @test dimension(1u"m" |> us"nm")[:m] == 0
+
     # Refuses to convert to non-unit quantities:
     @test_throws AssertionError uconvert(1.2us"m", 1.0u"m")
     VERSION >= v"1.8" &&
@@ -824,25 +825,30 @@ end
         xs2 = x2 .|> us"g"
         @test typeof(xs2) <: Vector{<:Q{Float64,<:SymbolicDimensions{<:Any}}}
         @test xs2[2] ≈ Q(2000us"g")
+        @test ustrip(xs2[2]) ≈ 2000
         
         x_qa = QuantityArray(x)
         xs_qa = x_qa .|> uconvert(us"g")
         @test typeof(xs_qa) <: QuantityArray{Float64,1,<:SymbolicDimensions{<:Any}}
         @test xs_qa[2] ≈ Q(2000us"g")
+        @test ustrip(xs_qa[1]) ≈ 1000
 
         x_qa1 = QuantityArray(x)
         xs_qa1 = x_qa1 .|> us"g"
         @test typeof(xs_qa1) <: QuantityArray{Float64,1,<:SymbolicDimensions{<:Any}}
         @test xs_qa1[2] ≈ Q(2000us"g")
+        @test ustrip(xs_qa1[3]) ≈ 3000
 
         # Without vectorized call:
         xs_qa2 = x_qa |> uconvert(us"g")
         @test typeof(xs_qa2) <: QuantityArray{Float64,1,<:SymbolicDimensions{<:Any}}
         @test xs_qa2[2] ≈ Q(2000us"g")
+        @test ustrip(xs_qa2[2]) ≈ 2000
 
         xs_qa3 = x_qa |> us"g"
         @test typeof(xs_qa3) <: QuantityArray{Float64,1,<:SymbolicDimensions{<:Any}}
         @test xs_qa3[2] ≈ Q(2000us"g")
+        @test ustrip(xs_qa3[3]) ≈ 3000
     end
 end
 

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -807,6 +807,11 @@ end
     VERSION >= v"1.8" &&
         @test_throws "You passed a quantity" uconvert(1.2us"m", 1.0u"m")
 
+    # Refuses to convert to `Dimensions`:
+    @test_throws AssertionError uconvert(1u"m", 5.0us"m")
+    VERSION >= v"1.8" &&
+        @test_throws "You can only `uconvert`" uconvert(1u"m", 5.0us"m")
+
     for Q in (RealQuantity, Quantity, GenericQuantity)
         # Different types require converting both arguments:
         q = convert(Q{Float16}, 1.5u"g")
@@ -1791,6 +1796,7 @@ end
     @test [km, km] isa Vector{Quantity{T,SymbolicDimensionsSingleton{R}}} where {T,R}
     @test [km^2, km] isa Vector{Quantity{T,SymbolicDimensions{R}}} where {T,R}
 
+    @test km |> uconvert(us"m") == km |> us"m"
     # No issue when converting to SymbolicDimensionsSingleton (gets
     # converted)
     @test uconvert(km, u"m") == 0.001km

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -799,6 +799,8 @@ end
     @test dimension(qs)[:M_sun] == 1
     @test uexpand(qs) ≈ 5.0 * q
 
+    @test uconvert(us"nm",1u"m") == 1u"m" |> us"nm"
+    
     # Refuses to convert to non-unit quantities:
     @test_throws AssertionError uconvert(1.2us"m", 1.0u"m")
     VERSION >= v"1.8" &&
@@ -817,15 +819,30 @@ end
         @test typeof(xs) <: Vector{<:Q{Float64,<:SymbolicDimensions{<:Any}}}
         @test xs[2] ≈ Q(2000us"g")
 
+        # Arrays
+        x2 = [1.0, 2.0, 3.0] .* Q(u"kg")
+        xs2 = x2 .|> us"g"
+        @test typeof(xs2) <: Vector{<:Q{Float64,<:SymbolicDimensions{<:Any}}}
+        @test xs2[2] ≈ Q(2000us"g")
+        
         x_qa = QuantityArray(x)
         xs_qa = x_qa .|> uconvert(us"g")
         @test typeof(xs_qa) <: QuantityArray{Float64,1,<:SymbolicDimensions{<:Any}}
         @test xs_qa[2] ≈ Q(2000us"g")
 
+        x_qa1 = QuantityArray(x)
+        xs_qa1 = x_qa1 .|> us"g"
+        @test typeof(xs_qa1) <: QuantityArray{Float64,1,<:SymbolicDimensions{<:Any}}
+        @test xs_qa1[2] ≈ Q(2000us"g")
+
         # Without vectorized call:
         xs_qa2 = x_qa |> uconvert(us"g")
         @test typeof(xs_qa2) <: QuantityArray{Float64,1,<:SymbolicDimensions{<:Any}}
         @test xs_qa2[2] ≈ Q(2000us"g")
+
+        xs_qa3 = x_qa |> us"g"
+        @test typeof(xs_qa3) <: QuantityArray{Float64,1,<:SymbolicDimensions{<:Any}}
+        @test xs_qa3[2] ≈ Q(2000us"g")
     end
 end
 


### PR DESCRIPTION
Hi, great work since the start of the package!

With this PR I propose to provide
```
1u"m" |> us"nm"
```
in addition to 
```
1u"m" |> uconvert(us"nm")
```

Would be just more convenient, but may be I overlook some reason why this is not a good idea.
