### PR TITLE
Add angular units

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ so you can simply access these as `SymbolicUnits.cm` and `SymbolicConstants.h`,
 respectively.
 
 
-### Custom Units
+#### Custom Units
 
 You can create custom units with the `@register_unit` macro:
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,26 @@ Note that `SymbolicUnits` and `SymbolicConstants` are exported,
 so you can simply access these as `SymbolicUnits.cm` and `SymbolicConstants.h`,
 respectively.
 
+
+### Custom Units
+
+You can create custom units with the `@register_unit` macro:
+
+```julia
+julia> @register_unit OneFiveV 1.5u"V"
+```
+
+and then use it in calculations normally:
+
+```julia
+julia> x = us"OneFiveV"
+1.0 OneFiveV
+
+julia> x * 10u"A" |> uconvert(us"W")
+15.0 W
+```
+
+
 ### Arrays
 
 For working with an array of quantities that have the same dimensions,

--- a/src/units.jl
+++ b/src/units.jl
@@ -121,7 +121,7 @@ end
 
 # SI derived units
 @doc(
-    "Frequency in Hertz. Available variants: `nHz`, `μHz` (/`uHz`), `mHz`, `kHz`, `MHz`, `GHz`.",
+    "Frequency in Hertz. Available variants: `nHz`, `μHz` (/`uHz`), `mHz`, `kHz`, `MHz`, `GHz`, `rpm`.",
     Hz,
 )
 @doc(
@@ -215,6 +215,33 @@ end
     "Pressure in bars. Available variants: `mbar`.",
     bar,
 )
+
+## Angles
+@_lazy_register_unit rad DEFAULT_QUANTITY_TYPE(1.0)
+@_lazy_register_unit sr DEFAULT_QUANTITY_TYPE(1.0)
+
+@add_prefixes rad (n, μ, u, m)
+@add_prefixes sr ()
+
+@doc(
+    "Angle in radians. Note that the SI definition is simply 1 rad = 1, so use symbolic units to avoid this. Available variants: `nrad`, `μrad` (/`urad`), `mrad`, `deg`, `arcmin`, `arcsec`, `μarcsec` (/`uarcsec`), `marcsec`.",
+    rad,
+)
+@doc(
+    "Solid angle in steradians. Note that the SI definition is simply 1 sr = 1, so use symbolic units to avoid this.",
+    sr,
+)
+
+@_lazy_register_unit deg pi / 180 * rad
+@_lazy_register_unit arcmin deg / 60
+@_lazy_register_unit arcsec arcmin / 60
+
+@add_prefixes deg ()
+@add_prefixes arcmin ()
+@add_prefixes arcsec (μ, u, m)
+
+## Angular velocity
+@_lazy_register_unit rpm 2 * pi / min
 
 # Do not wish to define Gaussian units, as it changes
 # some formulas. Safer to force user to work exclusively in one unit system.

--- a/src/units.jl
+++ b/src/units.jl
@@ -121,7 +121,7 @@ end
 
 # SI derived units
 @doc(
-    "Frequency in Hertz. Available variants: `nHz`, `μHz` (/`uHz`), `mHz`, `kHz`, `MHz`, `GHz`, `rpm`.",
+    "Frequency in Hertz. Available variants: `nHz`, `μHz` (/`uHz`), `mHz`, `kHz`, `MHz`, `GHz`.",
     Hz,
 )
 @doc(
@@ -239,9 +239,6 @@ end
 @add_prefixes deg ()
 @add_prefixes arcmin ()
 @add_prefixes arcsec (μ, u, m)
-
-## Angular velocity
-@_lazy_register_unit rpm 2 * pi / min
 
 # Do not wish to define Gaussian units, as it changes
 # some formulas. Safer to force user to work exclusively in one unit system.

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -735,7 +735,7 @@ end
     # Helpful error if symbol not found:
     sym5 = dimension(us"km/s")
     VERSION >= v"1.8" &&
-        @test_throws "rad is not available as a symbol" sym5.rad
+        @test_throws "my_special_symbol is not available as a symbol" sym5.my_special_symbol
 
     # Test deprecated method
     q = 1.5us"km/s"


### PR DESCRIPTION
Fixes #28 

@mikeingold since you have interest in using this, what do you think? 

Here I am using the SI definition that `1 rad = 1`. So to have "rad" actually show up in quantities you would need to use symbolic units, like the following:

```julia
julia> θ = 10.2us"deg"
10.2 deg

julia> r = 5us"km"
5.0 km

julia> θ * r |> uexpand
890.117918517108 m
```

which I think seems okay?