### PR TITLE
Make default parametric denominator of FixedRational `::Int64`

### DIFF
--- a/src/fixed_rational.jl
+++ b/src/fixed_rational.jl
@@ -32,7 +32,7 @@ val_denom(::Type{<:F}) where {F<:FixedRational} = Val(_denom(F))
 Base.eltype(::Type{<:FixedRational{T}}) where {T} = T
 
 const DEFAULT_NUMERATOR_TYPE = Int32
-const DEFAULT_DENOM = DEFAULT_NUMERATOR_TYPE(2^4 * 3^2 * 5^2 * 7)
+const DEFAULT_DENOM = 2^4 * 3^2 * 5^2 * 7
 
 (::Type{F})(x::F) where {F<:FixedRational} = x
 (::Type{F})(x::F2) where {T,T2,den,F<:FixedRational{T,den},F2<:FixedRational{T2,den}} = unsafe_fixed_rational(x.num, eltype(F), val_denom(F))

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -595,6 +595,12 @@ end
     @test promote_type(FixedRational{Int64,10},FixedRational{BigInt,10}) == FixedRational{BigInt,10}
     @test promote_type(Rational{Int8}, FixedRational{Int,12345}) == Rational{Int}
     @test promote_type(Int8, FixedRational{Int,12345}) == FixedRational{Int,12345}
+
+    # Bug where user would create a FixedRational{::Type{Int32}, ::Int64} and get stack overflow,
+    # because the stored type was FixedRational{::Type{Int32}, ::Int32}
+    x = 10u"m"
+    user_quantity = Quantity(10.0, Dimensions{FixedRational{Int32,25200}}(1, 0, 0, 0, 0, 0, 0))
+    @test x == user_quantity
 end
 
 @testset "Quantity promotion" begin
@@ -1978,7 +1984,7 @@ end
 push!(LOAD_PATH, joinpath(@__DIR__, "precompile_test"))
 
 using ExternalUnitRegistration: MyWb
-@testset "Type of Extenral Unit" begin
+@testset "Type of External Unit" begin
     @test MyWb isa DEFAULT_QUANTITY_TYPE
     @test MyWb/u"m^2*kg*s^-2*A^-1" == 1.0
 end


### PR DESCRIPTION
This fixes a weird issue where the user would write out a quantity explicitly, like:

```julia
user_quantity = Quantity(10.0, Dimensions{FixedRational{Int32,25200}}(1, 0, 0, 0, 0, 0, 0))
```

and be surprised when this is not the same type as `10u"m"`. The reason for this is that `FixedRational{Int32,25200}} != FixedRational{Int32,Int32(25200)}}`!

So, this sets the default denominator to have `Int64` type so that the user can write out an integer and not be surprised when it's a different type from the standard.