### PR TITLE
feat: export FixedRational

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ you can use a `QuantityArray`:
 
 ```julia
 julia> ar = QuantityArray(rand(3), u"m/s")
-3-element QuantityArray(::Vector{Float64}, ::Quantity{Float64, Dimensions{DynamicQuantities.FixedRational{Int32, 25200}}}):
+3-element QuantityArray(::Vector{Float64}, ::Quantity{Float64, Dimensions{FixedRational{Int32, 25200}}}):
  0.2729202669351497 m s⁻¹
  0.992546340360901 m s⁻¹
  0.16863543422972482 m s⁻¹
@@ -410,9 +410,9 @@ the type you wish to use as the second argument to `Quantity`:
 ```julia
 julia> using DynamicQuantities
 
-julia> R8 = Dimensions{DynamicQuantities.FixedRational{Int8,6}};
+julia> R8 = Dimensions{FixedRational{Int8,6}};
 
-julia> R32 = Dimensions{DynamicQuantities.FixedRational{Int32,2^4 * 3^2 * 5^2 * 7}};  # Default
+julia> R32 = Dimensions{FixedRational{Int32,2^4 * 3^2 * 5^2 * 7}};  # Default
 
 julia> q8 = [Quantity{Float64,R8}(randn(), length=rand(-2:2)) for i in 1:1000];
 

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -33,6 +33,6 @@ Filter  = t -> !(t in [ustrip, dimension, ulength, umass, utime, ucurrent, utemp
 ### FixedRational
 
 ```@docs
-DynamicQuantities.FixedRational
+FixedRational
 DynamicQuantities.denom
 ```

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -3,6 +3,7 @@ module DynamicQuantities
 export Units, Constants, SymbolicUnits, SymbolicConstants
 export AbstractQuantity, AbstractGenericQuantity, AbstractRealQuantity, UnionAbstractQuantity
 export Quantity, GenericQuantity, RealQuantity
+export FixedRational
 export AbstractDimensions, Dimensions, NoDims
 export AbstractSymbolicDimensions, SymbolicDimensions, SymbolicDimensionsSingleton
 export QuantityArray

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1,5 +1,5 @@
 using DynamicQuantities
-using DynamicQuantities: FixedRational, NoDims, AbstractSymbolicDimensions
+using DynamicQuantities: NoDims, AbstractSymbolicDimensions
 using DynamicQuantities: DEFAULT_QUANTITY_TYPE, DEFAULT_DIM_BASE_TYPE, DEFAULT_DIM_TYPE, DEFAULT_VALUE_TYPE
 using DynamicQuantities: array_type, value_type, dim_type, quantity_type
 using DynamicQuantities: GenericQuantity, with_type_parameters, constructorof


### PR DESCRIPTION
This internal type is a very stable part of DynamicQuantities so I would like to export it so users can more easily change the default bits.

Also it will make printing slightly less verbose as dimensions would be `Dimensions{FixedRational{...}}` rather than `Dimensions{DynamicQuantities.FixedRational{...}}`.