### PR TITLE
Fix reflection by using `dimension_names`

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -15,7 +15,7 @@ end
     # Test a function over all dimensions
     output = Expr(:&&)
     dimension_type = promote_type(args...)
-    for dim in Base.fieldnames(dimension_type)
+    for dim in dimension_names(dimension_type)
         f_expr = :(f())
         for i=1:length(args)
             push!(f_expr.args, :(args[$i].$dim))


### PR DESCRIPTION
Seems sometimes inference issues propagate to the `all_dimensions` function's use of `Base.fieldnames`. Switching to the internally-defined `dimension_names` fixes it. 

TODO: verify this does not affect performance!