### PR TITLE
Add DispatchDoctor.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.14.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
+DispatchDoctor = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
 Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
@@ -23,6 +24,7 @@ DynamicQuantitiesUnitfulExt = "Unitful"
 
 [compat]
 Compat = "3.42, 4"
+DispatchDoctor = "0.4"
 LinearAlgebra = "1"
 Measurements = "2"
 PackageExtensionCompat = "1.0.2"

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -12,24 +12,30 @@ export ustrip, dimension
 export ulength, umass, utime, ucurrent, utemperature, uluminosity, uamount
 export uparse, @u_str, sym_uparse, @us_str, uexpand, uconvert, @register_unit
 
-
-include("internal_utils.jl")
-include("fixed_rational.jl")
-include("write_once_read_many.jl")
-include("types.jl")
-include("utils.jl")
-include("math.jl")
-include("arrays.jl")
-include("units.jl")
-include("constants.jl")
-include("uparse.jl")
-include("symbolic_dimensions.jl")
-include("complex.jl")
-include("register_units.jl")
-include("disambiguities.jl")
-
-include("deprecated.jl")
+# Deprecated:
 export expand_units
+
+using DispatchDoctor: @stable
+
+@stable default_mode = "disable" begin
+    include("internal_utils.jl")
+    include("fixed_rational.jl")
+    include("write_once_read_many.jl")
+    include("types.jl")
+    include("utils.jl")
+    include("math.jl")
+    include("arrays.jl")
+    include("units.jl")
+    include("constants.jl")
+    include("uparse.jl")
+    include("symbolic_dimensions.jl")
+    include("complex.jl")
+    include("register_units.jl")
+    include("disambiguities.jl")
+
+    include("deprecated.jl")
+end
+
 
 import PackageExtensionCompat: @require_extensions
 import .Units

--- a/src/DynamicQuantities.jl
+++ b/src/DynamicQuantities.jl
@@ -17,7 +17,7 @@ export expand_units
 
 using DispatchDoctor: @stable
 
-@stable default_mode = "disable" begin
+@stable default_mode="disable" begin
     include("internal_utils.jl")
     include("fixed_rational.jl")
     include("write_once_read_many.jl")

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -291,7 +291,7 @@ end
 
 # Basically, we want to solve a single element to find the output dimension.
 # Then we can put results in the output `QuantityArray`.
-materialize_first(bc::Base.Broadcast.Broadcasted) = bc.f(materialize_first.(bc.args)...)
+materialize_first(bc::Base.Broadcast.Broadcasted) = bc.f(map(materialize_first, bc.args)...)
 
 # Base cases
 materialize_first(q::AbstractGenericQuantity{<:AbstractArray}) = new_quantity(typeof(q), first(ustrip(q)), dimension(q))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,3 +1,4 @@
+using DispatchDoctor: @unstable
 import Compat: allequal
 
 function map_dimensions(f::F, args::AbstractDimensions...) where {F<:Function}
@@ -48,10 +49,10 @@ The user should overload this function to define a custom type hierarchy.
 
 Also see `promote_quantity_on_quantity`.
 """
-@inline promote_quantity_on_value(::Type{<:Union{GenericQuantity,Quantity,RealQuantity}}, ::Type{<:Any}) = GenericQuantity
-@inline promote_quantity_on_value(::Type{<:Union{Quantity,RealQuantity}}, ::Type{<:Number}) = Quantity
-@inline promote_quantity_on_value(::Type{<:RealQuantity}, ::Type{<:Real}) = RealQuantity
-@inline promote_quantity_on_value(T, _) = T
+@unstable @inline promote_quantity_on_value(::Type{<:Union{GenericQuantity,Quantity,RealQuantity}}, ::Type{<:Any}) = GenericQuantity
+@unstable @inline promote_quantity_on_value(::Type{<:Union{Quantity,RealQuantity}}, ::Type{<:Number}) = Quantity
+@unstable @inline promote_quantity_on_value(::Type{<:RealQuantity}, ::Type{<:Real}) = RealQuantity
+@unstable @inline promote_quantity_on_value(T, _) = T
 
 """
     promote_quantity_on_quantity(Q1, Q2)
@@ -65,10 +66,10 @@ as that is the most specific type.
 
 Also see `promote_quantity_on_value`.
 """
-@inline promote_quantity_on_quantity(::Type{<:Union{GenericQuantity,Quantity,RealQuantity}}, ::Type{<:Union{GenericQuantity,Quantity,RealQuantity}}) = GenericQuantity
-@inline promote_quantity_on_quantity(::Type{<:Union{Quantity,RealQuantity}}, ::Type{<:Union{Quantity,RealQuantity}}) = Quantity
-@inline promote_quantity_on_quantity(::Type{<:RealQuantity}, ::Type{<:RealQuantity}) = RealQuantity
-@inline promote_quantity_on_quantity(::Type{Q}, ::Type{Q}) where {Q<:UnionAbstractQuantity} = Q
+@unstable @inline promote_quantity_on_quantity(::Type{<:Union{GenericQuantity,Quantity,RealQuantity}}, ::Type{<:Union{GenericQuantity,Quantity,RealQuantity}}) = GenericQuantity
+@unstable @inline promote_quantity_on_quantity(::Type{<:Union{Quantity,RealQuantity}}, ::Type{<:Union{Quantity,RealQuantity}}) = Quantity
+@unstable @inline promote_quantity_on_quantity(::Type{<:RealQuantity}, ::Type{<:RealQuantity}) = RealQuantity
+@unstable @inline promote_quantity_on_quantity(::Type{Q}, ::Type{Q}) where {Q<:UnionAbstractQuantity} = Q
 
 for (type1, _, _) in ABSTRACT_QUANTITY_TYPES, (type2, _, _) in ABSTRACT_QUANTITY_TYPES
     @eval function Base.promote_rule(::Type{Q1}, ::Type{Q2}) where {T1,T2,D1,D2,Q1<:$type1{T1,D1},Q2<:$type2{T2,D2}}
@@ -170,7 +171,7 @@ end
 Base.keys(q::UnionAbstractQuantity) = keys(ustrip(q))
 
 # If atol specified in kwargs, validate its dimensions and then strip units
-@inline function _validate_isapprox(dimcheck, kws)
+@inline @unstable function _validate_isapprox(dimcheck, kws)
     if haskey(kws, :atol)
         dimension(dimcheck) == dimension(kws[:atol]) || throw(DimensionError(dimcheck, kws[:atol]))
         return (; kws..., atol=ustrip(kws[:atol]))

--- a/test/LocalPreferences.toml
+++ b/test/LocalPreferences.toml
@@ -1,0 +1,3 @@
+[DynamicQuantities]
+instability_check = "error"
+instability_check_codegen = "min"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,8 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+DispatchDoctor = "8d63f2c5-f18a-4cf2-ba9d-b3f60fc568c8"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
-Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 Ratios = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SaferIntegers = "88634af6-177f-5301-88b8-7819386cfa38"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,7 +15,10 @@ end
 end
 
 @testitem "Unitful.jl integration tests" begin
-    include("test_unitful.jl")
+    using DispatchDoctor
+    allow_unstable() do
+        include("test_unitful.jl")
+    end
 end
 @testitem "ScientificTypes.jl integration tests" begin
     include("test_scitypes.jl")

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -1383,7 +1383,7 @@ end
             # There is no easy way to test whether it actually ran,
             # so we create a fake array type that has a custom `sizehint!`
             # which tells us it actually ran.
-            isdefined(Main, :MyCustomArray) || @eval begin
+            isdefined(@__MODULE__, :MyCustomArray) || @eval begin
                 mutable struct MyCustomArray{T,N} <: AbstractArray{T,N}
                     data::Array{T,N}
                     sizehint_called::Bool


### PR DESCRIPTION
Also fixes a few instabilities found by it, like

```diff
- materialize_first(bc::Base.Broadcast.Broadcasted) = bc.f(materialize_first.(bc.args)...)
+ materialize_first(bc::Base.Broadcast.Broadcasted) = bc.f(map(materialize_first, bc.args)...)
```

– surprisingly the former version is a real type instability.

I don't mark any extensions as stable yet. Unitful.jl of course would not work as its unstable. The others we can add later.