### PR TITLE
Add mu, m, k prefixes for Newtons

### DIFF
--- a/src/units.jl
+++ b/src/units.jl
@@ -106,7 +106,7 @@ end
 @_lazy_register_unit M mol / dm^3
 
 @add_prefixes Hz (n, μ, u, m, k, M, G)
-@add_prefixes N (μ, m, k)
+@add_prefixes N (μ, u, m, k)
 @add_prefixes Pa (k,)
 @add_prefixes J (k,)
 @add_prefixes W (m, k, M, G)
@@ -127,7 +127,7 @@ end
     Hz,
 )
 @doc(
-    "Force in Newtons.",
+    "Force in Newtons. Available variants: `μN` (/`uN`), `mN`, `kN`.",
     N,
 )
 @doc(

--- a/src/units.jl
+++ b/src/units.jl
@@ -106,7 +106,7 @@ end
 @_lazy_register_unit M mol / dm^3
 
 @add_prefixes Hz (n, μ, u, m, k, M, G)
-@add_prefixes N ()
+@add_prefixes N (μ, m, k)
 @add_prefixes Pa (k,)
 @add_prefixes J (k,)
 @add_prefixes W (m, k, M, G)


### PR DESCRIPTION
In my field (spacecraft propulsion), we regularly express thrusts in terms of micro-, milli-, and kilo- Newtons. This PR adds those prefixes.