### PR TITLE
Add some common units

### DIFF
--- a/src/units.jl
+++ b/src/units.jl
@@ -263,7 +263,7 @@ end
 ## Energy
 @_lazy_register_unit cal 4.184 * J
 
-@add_prefixes cal (k)
+@add_prefixes cal (k,)
 
 @doc(
     "Energy in calories. Available variants: `kcal`.",

--- a/src/units.jl
+++ b/src/units.jl
@@ -214,12 +214,20 @@ end
 
 ## Pressure
 @_lazy_register_unit bar 100 * kPa
+@_lazy_register_unit atm 101325 * Pa
+@_lazy_register_unit Torr 101325//760 * Pa
 
 @add_prefixes bar (m,)
+@add_prefixes atm ()
+@add_prefixes Torr (m,)
 
 @doc(
     "Pressure in bars. Available variants: `mbar`.",
     bar,
+    "Pressure in atmospheres.",
+    atm,
+    "Pressure in Torr. Available variants: `mTorr`.",
+    Torr,
 )
 
 ## Angles
@@ -251,6 +259,16 @@ end
 
 # Do not wish to define Gaussian units, as it changes
 # some formulas. Safer to force user to work exclusively in one unit system.
+
+## Energy
+@_lazy_register_unit cal 4.184 * J
+
+@add_prefixes cal (k)
+
+@doc(
+    "Energy in calories. Available variants: `kcal`.",
+    cal,
+)
 
 # Do not wish to define physical constants, as the number of symbols might lead to ambiguity.
 # The user should define these instead.

--- a/src/units.jl
+++ b/src/units.jl
@@ -215,7 +215,7 @@ end
 ## Pressure
 @_lazy_register_unit bar 100 * kPa
 @_lazy_register_unit Torr 101325//760 * Pa
-@_lazy_register_unit mmHg 101325//760 * Pa
+@_lazy_register_unit mmHg Torr
 
 @add_prefixes bar (m,)
 @add_prefixes Torr (m,)
@@ -224,8 +224,12 @@ end
 @doc(
     "Pressure in bars. Available variants: `mbar`.",
     bar,
+)
+@doc(
     "Pressure in Torr. Available variants: `mTorr`.",
     Torr,
+)
+@doc(
     "Pressure in mmHg.",
     mmHg,
 )

--- a/src/units.jl
+++ b/src/units.jl
@@ -214,20 +214,20 @@ end
 
 ## Pressure
 @_lazy_register_unit bar 100 * kPa
-@_lazy_register_unit atm 101325 * Pa
 @_lazy_register_unit Torr 101325//760 * Pa
+@_lazy_register_unit mmHg 101325//760 * Pa
 
 @add_prefixes bar (m,)
-@add_prefixes atm ()
 @add_prefixes Torr (m,)
+@add_prefixes mmHg ()
 
 @doc(
     "Pressure in bars. Available variants: `mbar`.",
     bar,
-    "Pressure in atmospheres.",
-    atm,
     "Pressure in Torr. Available variants: `mTorr`.",
     Torr,
+    "Pressure in mmHg.",
+    mmHg,
 )
 
 ## Angles
@@ -259,16 +259,6 @@ end
 
 # Do not wish to define Gaussian units, as it changes
 # some formulas. Safer to force user to work exclusively in one unit system.
-
-## Energy
-@_lazy_register_unit cal 4.184 * J
-
-@add_prefixes cal (k,)
-
-@doc(
-    "Energy in calories. Available variants: `kcal`.",
-    cal,
-)
 
 # Do not wish to define physical constants, as the number of symbols might lead to ambiguity.
 # The user should define these instead.


### PR DESCRIPTION
In the spirit of #153 and #152 , adding some more units with prefixes, since I ran into the same situation as #151 of wanting to register new units.

Specifically, adding atmosphere (atm), Torr, and cal as pressure and energy units respectively. The fact that people in my field commonly use these somewhat-annoying units is one of the main reasons I use packages like this and Unitful.

I would be willing to go through e.g. https://github.com/PainterQubits/Unitful.jl/blob/master/src/pkgdefaults.jl and add more of the default units listed there, to avoid needing a multitude of this kind of pull request.