### PR TITLE
Basic Makie.jl support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,12 +10,14 @@ Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [weakdeps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
 DynamicQuantitiesLinearAlgebraExt = "LinearAlgebra"
+DynamicQuantitiesMakieExt = "Makie"
 DynamicQuantitiesMeasurementsExt = "Measurements"
 DynamicQuantitiesScientificTypesExt = "ScientificTypes"
 DynamicQuantitiesUnitfulExt = "Unitful"
@@ -23,6 +25,7 @@ DynamicQuantitiesUnitfulExt = "Unitful"
 [compat]
 DispatchDoctor = "0.4"
 LinearAlgebra = "1"
+Makie = "0.22.2"
 Measurements = "2"
 ScientificTypes = "3"
 TestItems = "0.1, 1"
@@ -32,6 +35,7 @@ julia = "1.10"
 
 [extras]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"

--- a/ext/DynamicQuantitiesMakieExt.jl
+++ b/ext/DynamicQuantitiesMakieExt.jl
@@ -1,0 +1,37 @@
+module DynamicQuantitiesMakieExt
+
+using DynamicQuantities: UnionAbstractQuantity, ustrip, dimension
+
+import Makie as M
+
+struct DQConversion <: M.AbstractDimConversion
+    quantities::M.Observable{Any}
+    DQConversion() = new(M.automatic)
+end
+
+M.expand_dimensions(::M.PointBased, y::AbstractVector{<:UnionAbstractQuantity}) = (keys(y), y)
+
+M.needs_tick_update_observable(conversion::DQConversion) = nothing
+
+M.create_dim_conversion(::Type{<:UnionAbstractQuantity}) = DQConversion()
+
+M.MakieCore.should_dim_convert(::Type{<:UnionAbstractQuantity}) = true
+
+M.convert_dim_value(::DQConversion, quantities) = [ustrip(q) for q in quantities]
+
+function M.convert_dim_observable(conversion::DQConversion, values_obs::M.Observable, deregister)
+    result = M.Observable(Float64[])
+    f = M.on(values_obs; update=true) do values
+        result[] = M.convert_dim_value(conversion, values)
+        conversion.quantities[] = values
+    end
+    push!(deregister, f)
+    return result
+end
+
+function M.get_ticks(conversion::DQConversion, ticks, scale, formatter, vmin, vmax)
+    tick_vals, labels = M.get_ticks(ticks, scale, formatter, vmin, vmax)
+    return tick_vals, string.(labels, string(dimension(conversion.quantities[])))
+end
+
+end


### PR DESCRIPTION
Closes #164

## Demo

```julia
using DynamicQuantities, GLMakie

fig = Figure()

y = 60:10:100

scatter(fig[1, 1], y * u"m")
scatter(fig[1, 2], QuantityArray(y, u"m"))
scatter(fig[2, 1], y * u"kg", y * u"m")
scatter(fig[2, 2], y * us"m/s/Hz")

fig
```

![example](https://github.com/user-attachments/assets/572894af-eda8-4119-9cf7-38bc1cce34d0)

## Makie TODO
- [ ] Heatmap
- [ ] Image
- [ ] Rich strings? see, e.g., [untitful impl](https://github.com/MakieOrg/Makie.jl/blob/d77c537884e139eb476cb552a8129ef270586e6b/src/dim-converts/unitful-integration.jl#L188)

## Package TODO
- [ ] unit tests
- [ ] documentation