### PR TITLE
fix: Bump CairoMakie compat in docs/Project.toml

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,5 +3,4 @@ CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-# TODO: update when https://github.com/MakieOrg/Makie.jl/pull/5137 merged
-CairoMakie = "0.15.3"
+CairoMakie = "0.15.10"


### PR DESCRIPTION
[Makie PR 5137](https://github.com/MakieOrg/Makie.jl/pull/5137) has been merged. (Superseded by [Makie PR 5280](https://github.com/MakieOrg/Makie.jl/pull/5280).)