### PR TITLE
feat: Add some more (astro)angle aliases

### DIFF
--- a/src/units.jl
+++ b/src/units.jl
@@ -242,7 +242,7 @@ end
 @add_prefixes sr ()
 
 @doc(
-    "Angle in radians. Note that the SI definition is simply 1 rad = 1, so use symbolic units to avoid this. Available variants: `nrad`, `μrad` (/`urad`), `mrad`, `deg`, `arcmin`, `arcsec`, `μarcsec` (/`uarcsec`), `marcsec`.",
+    "Angle in radians. Note that the SI definition is simply 1 rad = 1, so use symbolic units to avoid this. Available variants: `nrad`, `μrad` (/`urad`), `mrad`, `deg` (/`°`), `arcmin`, `arcsec`, `μarcsec` (/`uarcsec`, `μas`, `uas`), `marcsec` (/`mas`).",
     rad,
 )
 @doc(
@@ -251,12 +251,18 @@ end
 )
 
 @_lazy_register_unit deg pi / 180 * rad
+@_lazy_register_unit ° deg
 @_lazy_register_unit arcmin deg / 60
 @_lazy_register_unit arcsec arcmin / 60
 
 @add_prefixes deg ()
 @add_prefixes arcmin ()
 @add_prefixes arcsec (μ, u, m)
+
+# Standard astronomy abbreviations for (sub)arcsecond angles
+@_lazy_register_unit μas μarcsec
+@_lazy_register_unit uas uarcsec
+@_lazy_register_unit mas marcsec
 
 ## Magnetic flux densities
 @_lazy_register_unit Gauss 1e-4 * T

--- a/test/unittests.jl
+++ b/test/unittests.jl
@@ -703,6 +703,17 @@ end
     @test ustrip(z) ≈ 60 * 60 * 24 * 365.25
     @test z == uparse("yr")
 
+    # `°` is an alias for `deg`
+    @test u"°" === u"deg"
+    @test u"90°" ≈ u"rad" * π / 2
+    @test uexpand(us"°") == uexpand(us"deg")
+
+    # `mas`/`μas`/`uas` are astronomy aliases for (sub)arcsecond angles
+    @test u"mas" === u"marcsec"
+    @test u"μas" === u"μarcsec"
+    @test u"uas" === u"uarcsec"
+    @test u"μas" === u"uas"
+
     # Test type stability of extreme range of units
     @test typeof(u"1") == DEFAULT_QUANTITY_TYPE
     @test typeof(u"1f0") == DEFAULT_QUANTITY_TYPE


### PR DESCRIPTION
Howdy, this adds a `°` alias for `deg`, along with additional astro friendly aliases: `mas` for `marcsec`, and `μas/uas` for `μarcsec`.

Happy to take those out if it doesn't fit the design philosophy here, but just wanted to check first, thanks!